### PR TITLE
disable play and slider on empty viewer

### DIFF
--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -18,6 +18,7 @@ interface PlayBackProps {
     onTimeChange: (time: number) => void;
     loading: boolean;
     timeStep: number;
+    isEmpty: boolean;
 }
 
 const PlayBackControls = ({
@@ -32,6 +33,7 @@ const PlayBackControls = ({
     onTimeChange,
     loading,
     timeStep,
+    isEmpty,
 }: PlayBackProps) => {
     const handleTimeChange = (sliderValue: number | [number, number]): void => {
         onTimeChange(sliderValue as number); // slider can be a list of numbers, but we're just using a single value
@@ -96,6 +98,7 @@ const PlayBackControls = ({
                     icon={isPlaying ? Icons.Pause : Icons.Play} // TODO: load these as fonts instead of images
                     onClick={isPlaying ? pauseHandler : playHandler}
                     loading={loading}
+                    disabled={isEmpty}
                 />
             </Tooltip>
             <Tooltip
@@ -120,7 +123,7 @@ const PlayBackControls = ({
                 step={timeStep}
                 min={firstFrameTime}
                 max={lastFrameTime}
-                disabled={loading}
+                disabled={loading || isEmpty}
             />
             <div className={styles.time}>
                 <p>

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -16,7 +16,7 @@ const si = require("si-prefix");
 import { State } from "../../state/types";
 import selectionStateBranch from "../../state/selection";
 import metadataStateBranch from "../../state/metadata";
-import { VIEWER_SUCCESS } from "../../state/metadata/constants";
+import { VIEWER_EMPTY, VIEWER_SUCCESS } from "../../state/metadata/constants";
 import {
     ChangeTimeAction,
     ResetDragOverViewerAction,
@@ -355,6 +355,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             timeStep,
             isBuffering,
             isPlaying,
+            viewerStatus,
         } = this.props;
         return (
             <div
@@ -396,6 +397,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
                     firstFrameTime={firstFrameTime}
                     lastFrameTime={lastFrameTime}
                     loading={isBuffering}
+                    isEmpty={viewerStatus === VIEWER_EMPTY}
                 />
                 <ScaleBar label={this.state.scaleBarLabel} />
                 <CameraControls


### PR DESCRIPTION
Passing in isEmpty to disable play button and slider when the viewer is empty. 

the step forward and step back buttons are already disabled on empty viewer because time === startTime === endTime

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
