### PR TITLE
Feature/Show a "Reset views" button on plot hover

### DIFF
--- a/src/components/Plots/index.tsx
+++ b/src/components/Plots/index.tsx
@@ -25,7 +25,12 @@ export default class Plots extends React.Component<PlotsProps, {}> {
                             data={plot.data}
                             useResizeHandler={true}
                             layout={plot.layout}
-                            config={{ displayModeBar: false }}
+                            // config attributes:
+                            // https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L23
+                            config={{
+                                modeBarButtons: [["resetViews"]],
+                                displaylogo: false,
+                            }}
                             // onClick={onPointClicked}
                             // onClickAnnotation={this.clickedAnnotation}
                             // onHover={onPlotHovered}


### PR DESCRIPTION
Graham brought up the point that people could get "lost" in the plots, where they accidentally (or intentionally) zoom in on the plot and don't know how to zoom back out by double-clicking.
More context in Slack: https://allencellscience.slack.com/archives/CFT511CE4/p1608147918103100

Plotly offers a built-in "mode bar" that can display an array of buttons on hover. This mode bar is customizable, so I added just the "Reset views" button. When you hover over a plot, the button (house-shaped icon) appears. When you hover over the button, a tooltip "Reset views" appears.

![image (1)](https://user-images.githubusercontent.com/12690133/102414510-86e45300-3fab-11eb-99e8-2b5da34187e0.png)

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
