### PR TITLE
adjusted colors of disabled buttons

### DIFF
--- a/src/components/PlaybackControls/style.css
+++ b/src/components/PlaybackControls/style.css
@@ -24,8 +24,9 @@
 }
 
 .btn button[disabled] {
-    color: var(--dark-theme-btn-disabled-color);
     border-radius: 3px;
+    background-color: var(--dark-theme-btn-bg);
+    border-color: transparent!important;
 }
 .slider {
     flex: 3;

--- a/src/styles/ant-vars.less
+++ b/src/styles/ant-vars.less
@@ -103,9 +103,9 @@ https://github.com/ant-design/ant-design/blob/master/components/style/themes/def
 @btn-danger-bg          : @background-color-base;
 @btn-danger-border      : @border-color-base;
 
-@btn-disable-color      : lighten(@text-color, 10%);
-@btn-disable-bg         : lighten(@dark, 20%);
-@btn-disable-border     : lighten(@dark, 20%);
+@btn-disable-color      : fade(@text-color, 80%);
+@btn-disable-bg         : fade(lighten(@dark, 20%), 70%);
+@btn-disable-border     : fade(lighten(@dark, 20%), 70%);
 
 @btn-default-ghost-color: @primary-color;
 @btn-default-ghost-bg: transparent;


### PR DESCRIPTION
Sorry, I had pushed this commit, but it didn't actually resolve before I merged. 
Based on the comments on the previous PR, I adjusted the disabled colors. 

<img width="243" alt="Screen Shot 2020-12-16 at 5 29 45 PM" src="https://user-images.githubusercontent.com/5170636/102426834-f581da80-3fc4-11eb-99c4-7f0b60a0a38f.png">

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
