### PR TITLE
Feature/add version to covid trajectory title

### DIFF
--- a/src/constants/networked-trajectories.ts
+++ b/src/constants/networked-trajectories.ts
@@ -33,7 +33,7 @@ const TRAJECTORIES: TrajectoryDisplayData[] = [
     {
         modelName: "SARS-CoV-2 Dynamics in Human Lung Epithelium",
         id: "pc4covid19.simularium",
-        title: "SARS-CoV-2 Dynamics in Human Lung Epithelium",
+        title: "SARS-CoV-2 Dynamics in Human Lung Epithelium (v4.1)",
         totalSimulatedTime: "4h",
         authors: "Michael Getz et al.",
         publication: {


### PR DESCRIPTION
This is a short-term implementation for this [request from Blair](https://allencellscience.slack.com/archives/CFT511CE4/p1608317864117100): "Paul Macklin said it would be nice if we can add a label for the version of the covid model, we're using v4.1. should we just add it to the end of the model name? a badge would be cool in the future"

Now the version name (v4.1) shows on the library card, the Load Model dropdown, and on top of the viewer.

In the future: [Find a good way to display the simulation version](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1247?filter=10408)

![image](https://user-images.githubusercontent.com/12690133/102652686-c2555d80-4122-11eb-8ef7-31fb97ee7d3c.png)

![image](https://user-images.githubusercontent.com/12690133/102652547-b9fd2280-4122-11eb-849f-270e46acf807.png)


**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
