### PR TITLE
Fix/simulation keeps playing when user is trying to scrub

### DIFF
--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -47,7 +47,7 @@ const PlayBackControls = ({
         // but we're just using a single value
         onTimeChange(sliderValue as number);
         if (isPlaying) {
-            // Need to save the sliderValue in local state to use in handleSliderMouseUp,
+            // Need to save the sliderValue as targetPlayTime to use in handleSliderMouseUp,
             // because the sliderValue argument available in handleSliderMouseUp is not accurate
             // when the time between mouse down and mouse up is short.
             setTargetPlayTime(sliderValue as number);

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -39,8 +39,12 @@ const PlayBackControls = ({
     const [wasPlaying, setWasPlaying] = useState(false);
     const [targetPlayTime, setTargetPlayTime] = useState(-1);
 
+    // - Gets called once when the user clicks on the slider to skip to a specific time
+    // - Gets called multiple times when user is scrubbing (every time the play head
+    //     passes through a time value associated with a frame)
     const handleTimeChange = (sliderValue: number | [number, number]): void => {
-        // slider can be a list of numbers, but we're just using a single value
+        // sliderValue can be an array of numbers (representing a selected range),
+        // but we're just using a single value
         setTargetPlayTime(sliderValue as number);
         if (isPlaying) {
             setWasPlaying(true);

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -46,6 +46,7 @@ const PlayBackControls = ({
         // sliderValue can be an array of numbers (representing a selected range),
         // but we're just using a single value
         setTargetPlayTime(sliderValue as number);
+        onTimeChange(sliderValue as number);
         if (isPlaying) {
             setWasPlaying(true);
             pauseHandler();
@@ -53,13 +54,9 @@ const PlayBackControls = ({
     };
 
     const handleSliderMouseUp = (): void => {
-        // Resume playing at targetPlayTime if simulation was playing before,
-        // otherwise just skip to targetPlayTime without resuming.
         if (wasPlaying) {
             playHandler(targetPlayTime);
             setWasPlaying(false);
-        } else {
-            onTimeChange(targetPlayTime);
         }
         setTargetPlayTime(-1);
     };

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -36,6 +36,7 @@ const PlayBackControls = ({
     isEmpty,
 }: PlayBackProps) => {
     const [unitIndex, setUnitIndex] = useState(0);
+    // Where to resume playing if simulation was playing before scrubbing
     const [targetPlayTime, setTargetPlayTime] = useState(-1);
 
     // - Gets called once when the user clicks on the slider to skip to a specific time
@@ -51,6 +52,9 @@ const PlayBackControls = ({
             // when the time between mouse down and mouse up is short.
             setTargetPlayTime(sliderValue as number);
             pauseHandler();
+        } else if (targetPlayTime >= 0) {
+            // Update targetPlayTime if user is still dragging
+            setTargetPlayTime(sliderValue as number);
         }
     };
 

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -7,7 +7,7 @@ import Icons from "../Icons";
 
 const styles = require("./style.css");
 interface PlayBackProps {
-    playHandler: () => void;
+    playHandler: (timeOverride?: number) => void;
     time: number;
     pauseHandler: () => void;
     prevHandler: () => void;
@@ -37,25 +37,38 @@ const PlayBackControls = ({
 }: PlayBackProps) => {
     const [unitIndex, setUnitIndex] = useState(0);
     const [wasPlayingBeforeScrubbing, setWasPlayingBeforeScrubbing] = useState(
-        false
+        -1
     );
 
     const handleTimeChange = (sliderValue: number | [number, number]): void => {
-        onTimeChange(sliderValue as number); // slider can be a list of numbers, but we're just using a single value
+        console.log("handleTimeChange");
+        console.log(sliderValue);
         if (isPlaying) {
-            setWasPlayingBeforeScrubbing(true);
+            console.log("isPlaying");
+            setWasPlayingBeforeScrubbing(sliderValue as number);
             pauseHandler();
+        } else if (wasPlayingBeforeScrubbing >= 0) {
+            console.log("not playing, still dragging");
+            setWasPlayingBeforeScrubbing(sliderValue as number);
+        } else {
+            console.log("onTimeChange");
+            onTimeChange(sliderValue as number); // slider can be a list of numbers, but we're just using a single value
         }
     };
 
     const handleSliderMouseUp = (
         sliderValue: number | [number, number]
     ): void => {
-        if (wasPlayingBeforeScrubbing) {
-            onTimeChange(sliderValue as number);
-            playHandler();
+        console.log("mouseUp");
+        if (wasPlayingBeforeScrubbing >= 0) {
+            console.log("wasPlayingBefore");
+            console.log(
+                "wasPlayingBeforeScrubbing:",
+                wasPlayingBeforeScrubbing
+            );
+            playHandler(wasPlayingBeforeScrubbing);
         }
-        setWasPlayingBeforeScrubbing(false);
+        setWasPlayingBeforeScrubbing(-1);
     };
 
     const units = ["s", "ms", "\u03BCs", "ns"];
@@ -126,7 +139,7 @@ const PlayBackControls = ({
                     className={btnClassNames}
                     size="small"
                     icon={isPlaying ? Icons.Pause : Icons.Play}
-                    onClick={isPlaying ? pauseHandler : playHandler}
+                    onClick={isPlaying ? pauseHandler : () => playHandler()}
                     loading={loading}
                     disabled={isEmpty}
                 />
@@ -159,7 +172,11 @@ const PlayBackControls = ({
                 </Button>
             </Tooltip>
             <Slider
-                value={time}
+                value={
+                    wasPlayingBeforeScrubbing >= 0
+                        ? wasPlayingBeforeScrubbing
+                        : time
+                }
                 onChange={handleTimeChange}
                 onAfterChange={handleSliderMouseUp}
                 tooltipVisible={false}

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -57,11 +57,11 @@ const PlayBackControls = ({
         // otherwise just skip to targetPlayTime without resuming.
         if (wasPlaying) {
             playHandler(targetPlayTime);
+            setWasPlaying(false);
         } else {
             onTimeChange(targetPlayTime);
         }
         setTargetPlayTime(-1);
-        setWasPlaying(false);
     };
 
     const units = ["s", "ms", "\u03BCs", "ns"];

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -63,10 +63,7 @@ const PlayBackControls = ({
 
     const units = ["s", "ms", "\u03BCs", "ns"];
     const roundNumber = (num: number) => parseFloat(Number(num).toPrecision(3));
-    const displayTime = targetPlayTime >= 0 ? targetPlayTime : time;
-    const roundedTime = displayTime
-        ? roundNumber(displayTime * 1000 ** unitIndex)
-        : 0;
+    const roundedTime = time ? roundNumber(time * 1000 ** unitIndex) : 0;
     const roundedLastFrameTime = roundNumber(lastFrameTime * 1000 ** unitIndex);
 
     // Calculates display unit when lastFrameTime is updated, i.e., when a new trajectory is loaded
@@ -165,7 +162,7 @@ const PlayBackControls = ({
                 </Button>
             </Tooltip>
             <Slider
-                value={targetPlayTime >= 0 ? targetPlayTime : time}
+                value={time}
                 onChange={handleTimeChange}
                 onAfterChange={handleSliderMouseUp}
                 tooltipVisible={false}

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -36,44 +36,39 @@ const PlayBackControls = ({
     isEmpty,
 }: PlayBackProps) => {
     const [unitIndex, setUnitIndex] = useState(0);
-    const [wasPlayingBeforeScrubbing, setWasPlayingBeforeScrubbing] = useState(
-        -1
-    );
+    const [targetPlayTime, setTargetPlayTime] = useState(-1);
 
     const handleTimeChange = (sliderValue: number | [number, number]): void => {
         console.log("handleTimeChange");
         console.log(sliderValue);
         if (isPlaying) {
             console.log("isPlaying");
-            setWasPlayingBeforeScrubbing(sliderValue as number);
+            // slider can be a list of numbers, but we're just using a single value
+            setTargetPlayTime(sliderValue as number);
             pauseHandler();
-        } else if (wasPlayingBeforeScrubbing >= 0) {
+        } else if (targetPlayTime >= 0) {
             console.log("not playing, still dragging");
-            setWasPlayingBeforeScrubbing(sliderValue as number);
+            setTargetPlayTime(sliderValue as number);
         } else {
             console.log("onTimeChange");
-            onTimeChange(sliderValue as number); // slider can be a list of numbers, but we're just using a single value
+            onTimeChange(sliderValue as number);
         }
     };
 
-    const handleSliderMouseUp = (
-        sliderValue: number | [number, number]
-    ): void => {
+    const handleSliderMouseUp = (): void => {
         console.log("mouseUp");
-        if (wasPlayingBeforeScrubbing >= 0) {
-            console.log("wasPlayingBefore");
-            console.log(
-                "wasPlayingBeforeScrubbing:",
-                wasPlayingBeforeScrubbing
-            );
-            playHandler(wasPlayingBeforeScrubbing);
+        if (targetPlayTime >= 0) {
+            playHandler(targetPlayTime);
+            setTargetPlayTime(-1);
         }
-        setWasPlayingBeforeScrubbing(-1);
     };
 
     const units = ["s", "ms", "\u03BCs", "ns"];
     const roundNumber = (num: number) => parseFloat(Number(num).toPrecision(3));
-    const roundedTime = time ? roundNumber(time * 1000 ** unitIndex) : 0;
+    const displayTime = targetPlayTime >= 0 ? targetPlayTime : time;
+    const roundedTime = displayTime
+        ? roundNumber(displayTime * 1000 ** unitIndex)
+        : 0;
     const roundedLastFrameTime = roundNumber(lastFrameTime * 1000 ** unitIndex);
 
     // Calculates display unit when lastFrameTime is updated, i.e., when a new trajectory is loaded
@@ -172,11 +167,7 @@ const PlayBackControls = ({
                 </Button>
             </Tooltip>
             <Slider
-                value={
-                    wasPlayingBeforeScrubbing >= 0
-                        ? wasPlayingBeforeScrubbing
-                        : time
-                }
+                value={targetPlayTime >= 0 ? targetPlayTime : time}
                 onChange={handleTimeChange}
                 onAfterChange={handleSliderMouseUp}
                 tooltipVisible={false}

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -36,31 +36,28 @@ const PlayBackControls = ({
     isEmpty,
 }: PlayBackProps) => {
     const [unitIndex, setUnitIndex] = useState(0);
+    const [wasPlaying, setWasPlaying] = useState(false);
     const [targetPlayTime, setTargetPlayTime] = useState(-1);
 
     const handleTimeChange = (sliderValue: number | [number, number]): void => {
-        console.log("handleTimeChange");
-        console.log(sliderValue);
+        // slider can be a list of numbers, but we're just using a single value
+        setTargetPlayTime(sliderValue as number);
         if (isPlaying) {
-            console.log("isPlaying");
-            // slider can be a list of numbers, but we're just using a single value
-            setTargetPlayTime(sliderValue as number);
+            setWasPlaying(true);
             pauseHandler();
-        } else if (targetPlayTime >= 0) {
-            console.log("not playing, still dragging");
-            setTargetPlayTime(sliderValue as number);
-        } else {
-            console.log("onTimeChange");
-            onTimeChange(sliderValue as number);
         }
     };
 
     const handleSliderMouseUp = (): void => {
-        console.log("mouseUp");
-        if (targetPlayTime >= 0) {
+        // Resume playing at targetPlayTime if simulation was playing before,
+        // otherwise just skip to targetPlayTime without resuming.
+        if (wasPlaying) {
             playHandler(targetPlayTime);
-            setTargetPlayTime(-1);
+        } else {
+            onTimeChange(targetPlayTime);
         }
+        setTargetPlayTime(-1);
+        setWasPlaying(false);
     };
 
     const units = ["s", "ms", "\u03BCs", "ns"];

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -35,11 +35,28 @@ const PlayBackControls = ({
     timeStep,
     isEmpty,
 }: PlayBackProps) => {
+    const [unitIndex, setUnitIndex] = useState(0);
+    const [wasPlayingBeforeScrubbing, setWasPlayingBeforeScrubbing] = useState(
+        false
+    );
+
     const handleTimeChange = (sliderValue: number | [number, number]): void => {
         onTimeChange(sliderValue as number); // slider can be a list of numbers, but we're just using a single value
+        if (isPlaying) {
+            setWasPlayingBeforeScrubbing(true);
+            pauseHandler();
+        }
     };
 
-    const [unitIndex, setUnitIndex] = useState(0);
+    const handleSliderMouseUp = (
+        sliderValue: number | [number, number]
+    ): void => {
+        if (wasPlayingBeforeScrubbing) {
+            onTimeChange(sliderValue as number);
+            playHandler();
+        }
+        setWasPlayingBeforeScrubbing(false);
+    };
 
     const units = ["s", "ms", "\u03BCs", "ns"];
     const roundNumber = (num: number) => parseFloat(Number(num).toPrecision(3));
@@ -144,6 +161,7 @@ const PlayBackControls = ({
             <Slider
                 value={time}
                 onChange={handleTimeChange}
+                onAfterChange={handleSliderMouseUp}
                 tooltipVisible={false}
                 className={[styles.slider, styles.item].join(" ")}
                 step={timeStep}

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -36,7 +36,6 @@ const PlayBackControls = ({
     isEmpty,
 }: PlayBackProps) => {
     const [unitIndex, setUnitIndex] = useState(0);
-    const [wasPlaying, setWasPlaying] = useState(false);
     const [targetPlayTime, setTargetPlayTime] = useState(-1);
 
     // - Gets called once when the user clicks on the slider to skip to a specific time
@@ -45,20 +44,19 @@ const PlayBackControls = ({
     const handleTimeChange = (sliderValue: number | [number, number]): void => {
         // sliderValue can be an array of numbers (representing a selected range),
         // but we're just using a single value
-        setTargetPlayTime(sliderValue as number);
         onTimeChange(sliderValue as number);
         if (isPlaying) {
-            setWasPlaying(true);
+            setTargetPlayTime(sliderValue as number);
             pauseHandler();
         }
     };
 
     const handleSliderMouseUp = (): void => {
-        if (wasPlaying) {
+        // Resume playing if simulation was playing before
+        if (targetPlayTime >= 0) {
             playHandler(targetPlayTime);
-            setWasPlaying(false);
+            setTargetPlayTime(-1);
         }
-        setTargetPlayTime(-1);
     };
 
     const units = ["s", "ms", "\u03BCs", "ns"];

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -37,7 +37,10 @@ const PlayBackControls = ({
 }: PlayBackProps) => {
     const [unitIndex, setUnitIndex] = useState(0);
     // Where to resume playing if simulation was playing before scrubbing
-    const [targetPlayTime, setTargetPlayTime] = useState(-1);
+    const [
+        timeToResumeAfterScrubbing,
+        setTimeToResumeAfterScrubbing,
+    ] = useState(-1);
 
     // - Gets called once when the user clicks on the slider to skip to a specific time
     // - Gets called multiple times when user is scrubbing (every time the play head
@@ -47,22 +50,22 @@ const PlayBackControls = ({
         // but we're just using a single value
         onTimeChange(sliderValue as number);
         if (isPlaying) {
-            // Need to save the sliderValue as targetPlayTime to use in handleSliderMouseUp,
+            // Need to save the sliderValue as timeToResumeAfterScrubbing to use in handleSliderMouseUp,
             // because the sliderValue argument available in handleSliderMouseUp is not accurate
             // when the time between mouse down and mouse up is short.
-            setTargetPlayTime(sliderValue as number);
+            setTimeToResumeAfterScrubbing(sliderValue as number);
             pauseHandler();
-        } else if (targetPlayTime >= 0) {
-            // Update targetPlayTime if user is still dragging
-            setTargetPlayTime(sliderValue as number);
+        } else if (timeToResumeAfterScrubbing >= 0) {
+            // Update value if user is still dragging
+            setTimeToResumeAfterScrubbing(sliderValue as number);
         }
     };
 
     const handleSliderMouseUp = (): void => {
         // Resume playing if simulation was playing before
-        if (targetPlayTime >= 0) {
-            playHandler(targetPlayTime);
-            setTargetPlayTime(-1);
+        if (timeToResumeAfterScrubbing >= 0) {
+            playHandler(timeToResumeAfterScrubbing);
+            setTimeToResumeAfterScrubbing(-1);
         }
     };
 

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -46,6 +46,9 @@ const PlayBackControls = ({
         // but we're just using a single value
         onTimeChange(sliderValue as number);
         if (isPlaying) {
+            // Need to save the sliderValue in local state to use in handleSliderMouseUp,
+            // because the sliderValue argument available in handleSliderMouseUp is not accurate
+            // when the time between mouse down and mouse up is short.
             setTargetPlayTime(sliderValue as number);
             pauseHandler();
         }

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -212,6 +212,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         this.setState({ highlightId });
     }
 
+    // timeOverride is passed in when the user manipulates the playback slider
     public startPlay(timeOverride?: number) {
         const {
             time,

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -213,6 +213,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
     }
 
     // timeOverride is passed in when the user manipulates the playback slider
+    // because this.props.time sometimes doesn't get updated in time before mouseUp
     public startPlay(timeOverride?: number) {
         const {
             time,

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -212,7 +212,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         this.setState({ highlightId });
     }
 
-    public startPlay() {
+    public startPlay(timeOverride?: number) {
         const {
             time,
             timeStep,
@@ -222,7 +222,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             setBuffering,
             setIsPlaying,
         } = this.props;
-        let newTime = time;
+        let newTime = timeOverride || time;
         if (newTime + timeStep >= lastFrameTime) {
             newTime = firstFrameTime;
         }

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -224,7 +224,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             setBuffering,
             setIsPlaying,
         } = this.props;
-        let newTime = timeOverride || time;
+        let newTime = timeOverride !== undefined ? timeOverride : time;
         if (newTime + timeStep >= lastFrameTime) {
             newTime = firstFrameTime;
         }


### PR DESCRIPTION
Resolves: [Simulation keeps playing when user is trying to scrub](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1230)

**Current behavior:** When a simulation is playing, and a user drags the playhead without pressing the pause button first, the simulation keeps trying to play while the user is trying to scrub, so it becomes a tug-o-war. 

**Behavior implemented in this PR:** The simulation pauses when a user starts scrubbing, and once the user lets go (mouse up) the simulation automatically resumes at the new position. The user has full control when they're trying to scrub and doesn't have to compete with ongoing playback.

Thanks to Megan for tons of help with this issue.

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
