### PR TITLE
Fix/"skip 1 frame back" button is not disabled when starting time is not 0

### DIFF
--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -85,7 +85,7 @@ const PlayBackControls = ({
                     ])}
                     size="small"
                     onClick={prevHandler}
-                    disabled={time === 0 || loading}
+                    disabled={time === firstFrameTime || loading}
                     loading={loading}
                 >
                     {/* if loading, antd will show loading icon, otherwise, show our custom svg */}


### PR DESCRIPTION
Resolves: ["Skip 1 frame back" button is not disabled when t0 is not 0](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1256)

Easy fix that prevents a user interaction that would cause the app to hang. Not a problem with currently streamed files but noticed this issue with some of the latest test files.

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
