### PR TITLE
Feature/lazy update of time indicator on plots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3883,6 +3883,11 @@
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
+    "consolidated-events": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
+      "integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
+    },
     "const-max-uint32": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/const-max-uint32/-/const-max-uint32-1.0.2.tgz",
@@ -12500,6 +12505,16 @@
         "prop-types": "^15.6.2",
         "react-is": "^16.8.6",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-waypoint": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/react-waypoint/-/react-waypoint-9.0.3.tgz",
+      "integrity": "sha512-NRmyjW8CUBNNl4WpvBqLDgBs18rFUsixeHVHrRrFlWTdOlWP7eiDjptqlR/cJAPLD6RwP5XFCm3bi9OiofN3nA==",
+      "requires": {
+        "consolidated-events": "^1.1.0 || ^2.0.0",
+        "prop-types": "^15.0.0",
+        "react-is": "^16.6.3"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "react-plotly.js": "^2.5.0",
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.2.0",
+    "react-waypoint": "^9.0.3",
     "redux": "4.0.1",
     "redux-logic": "^2.1.1",
     "reselect": "4.0.0",

--- a/src/containers/Plot/index.tsx
+++ b/src/containers/Plot/index.tsx
@@ -59,21 +59,13 @@ class Plot extends React.Component<PlotProps, PlotState> {
 
     shouldComponentUpdate(nextProps: PlotProps, nextState: PlotState) {
         const { shouldRenderTimeIndicator } = this.props.plotConfig;
-        if (!shouldRenderTimeIndicator) return false;
-
-        if (this.state.isInView) {
-            return true;
-        } else if (!this.state.isInView && nextState.isInView) {
-            return true;
-        } else {
-            return false;
-        }
+        if (shouldRenderTimeIndicator && nextState.isInView) return true;
+        return false;
     }
 
     public render(): JSX.Element | null {
         const { plotConfig, time } = this.props;
         const { shouldRenderTimeIndicator, data, layout } = plotConfig;
-        console.log("rendering Plot:", layout.title);
 
         if (shouldRenderTimeIndicator) {
             // Position the time indicator line at current time (the time indicator should be the last
@@ -86,9 +78,11 @@ class Plot extends React.Component<PlotProps, PlotState> {
 
         return (
             <Waypoint
-                // debug={true}
+                key={layout.title as string}
                 onEnter={() => this.setState({ isInView: true })}
                 onLeave={() => this.setState({ isInView: false })}
+                topOffset={50}
+                bottomOffset={50}
             >
                 <div className={styles.container}>
                     <PlotlyPlot

--- a/src/containers/Plot/index.tsx
+++ b/src/containers/Plot/index.tsx
@@ -59,8 +59,7 @@ class Plot extends React.Component<PlotProps, PlotState> {
 
     shouldComponentUpdate(nextProps: PlotProps, nextState: PlotState) {
         const { shouldRenderTimeIndicator } = this.props.plotConfig;
-        if (shouldRenderTimeIndicator && nextState.isInView) return true;
-        return false;
+        return shouldRenderTimeIndicator && nextState.isInView
     }
 
     public render(): JSX.Element | null {


### PR DESCRIPTION
Resolves: [Optimize plot rendering to improve endocytosis playback speed](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1257)

### Summary

This is part 2 of the approach outlined in the Jira issue. Part 1 has already been implemented and merged.

Part 1 improved frame rate by having React only re-render plots that have a time indicator line during trajectory playback. This PR goes further to implement lazy updating of the time indicator line. Only the plots that are visible to the user at any given point ("above the fold" might be the correct term) will update during playback, i.e., have the time indicator line move along with the simulation. If at any point the user scrolls to reveal plots that weren't previously visible, the time indicator lines in those plots jump to the correct spot to get in sync with the current time. The jump happens fast and is barely noticeable.

### Performance

Part 1 improved frame rate (max speed went from ~288 to ~178 seconds per frame, or ~3 fps to ~6 fps, on my machine) for endocytosis. With this change (pt 2) I observed an additional improvement (up to ~8 fps of speed, or down to ~130 seconds per frame). 

![image](https://user-images.githubusercontent.com/12690133/105927875-b9955880-5ff9-11eb-8662-d0143f55cd23.png)

I did notice that the simulation tends to slow down gradually towards the end, i.e., faster playback at t = 3 than at t = 10. I didn't investigate deeply what is causing this, but profiling indicates that it has to do with the viewer -- the runtime for plotly operations remains consistent (~40 ms) throughout the simulation.

### Code changes

I used the [react-waypoint](https://github.com/civiccc/react-waypoint) library, which Megan suggested, to detect when each plot enters/leaves the view. I set top and bottom offsets as 50 px, so at least 50 px of a plot needs to be in the view in order for it to count as "in view."


**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes, including any helpful screenshots.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
