### PR TITLE
Feature/load file url

### DIFF
--- a/src/components/ErrorNotification/index.tsx
+++ b/src/components/ErrorNotification/index.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { notification } from "antd";
+import { convertToSentenceCase } from "../../util";
+
+interface ErrorNotificationProps {
+    message: string;
+    htmlData?: string;
+    onClose?: () => void;
+}
+
+const errorNotification = ({
+    message,
+    htmlData,
+    onClose,
+}: ErrorNotificationProps) => {
+    return notification.error({
+        message: convertToSentenceCase(message),
+        description:
+            (
+                <div
+                    dangerouslySetInnerHTML={{
+                        __html: htmlData as string,
+                    }}
+                />
+            ) || "",
+        duration: htmlData ? 0 : 4.5,
+        onClose: onClose,
+    });
+};
+
+export default errorNotification;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,6 +2,7 @@ export const APP_ID = "agentviz-ui";
 export const API_VERSION = "v1";
 export const HEADER_HEIGHT = 113;
 export const URL_PARAM_KEY_FILE_NAME = "trajFileName";
+export const URL_PARAM_KEY_USER_URL = "trajUrl";
 export const CHECKBOX_TYPE_STAR = "star";
 export type CHECKBOX_TYPE_STAR = typeof CHECKBOX_TYPE_STAR;
 export const TOOLTIP_COLOR = "#141219";

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -19,6 +19,7 @@ import {
     URL_PARAM_KEY_USER_URL,
 } from "../../constants";
 import {
+    LoadViaUrlAction,
     LocalSimFile,
     RequestLocalFileAction,
     RequestNetworkFileAction,
@@ -48,6 +49,7 @@ interface AppProps {
     dragOverViewer: ActionCreator<DragOverViewerAction>;
     resetDragOverViewer: ActionCreator<ResetDragOverViewerAction>;
     viewerStatus: string;
+    loadViaUrl: ActionCreator<LoadViaUrlAction>;
 }
 
 interface AppState {
@@ -70,7 +72,7 @@ class App extends React.Component<AppProps, AppState> {
             setSimulariumController,
             changeToNetworkedFile,
             simulariumController,
-            changeToLocalSimulariumFile,
+            loadViaUrl,
         } = this.props;
         const current = this.interactiveContent.current;
 
@@ -116,34 +118,7 @@ class App extends React.Component<AppProps, AppState> {
                 setSimulariumController(controller);
                 return;
             }
-            fetch(verifiedUrl)
-                .then((data) => data.json())
-                .then((json) => {
-                    const urlSplit = verifiedUrl.split("/");
-                    const name = urlSplit[urlSplit.length - 1];
-                    console.log(name);
-                    changeToLocalSimulariumFile(
-                        {
-                            name, //TODO: add this to metadata about the file
-                            data: json,
-                            lastModified: Date.now(), //TODO: add this to metadata about the file
-                        },
-                        controller
-                    );
-                })
-                .catch((error) => {
-                    notification.error({
-                        message: `${userTrajectoryUrl} failed to fetch`,
-                        description: error.message,
-                        onClose: () => {
-                            history.replaceState(
-                                {},
-                                "",
-                                `${location.origin}${location.pathname}`
-                            );
-                        },
-                    });
-                });
+            loadViaUrl(verifiedUrl, controller);
         } else {
             setSimulariumController(controller);
         }
@@ -245,6 +220,7 @@ const dispatchToPropsMap = {
     changeToNetworkedFile: metadataStateBranch.actions.changeToNetworkedFile,
     resetDragOverViewer: selectionStateBranch.actions.resetDragOverViewer,
     dragOverViewer: selectionStateBranch.actions.dragOverViewer,
+    loadViaUrl: metadataStateBranch.actions.loadViaUrl,
 };
 
 export default connect(

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ActionCreator } from "redux";
 import { connect } from "react-redux";
-import { Layout, notification } from "antd";
+import { Layout } from "antd";
 import queryString from "query-string";
 import { SimulariumController } from "@aics/simularium-viewer";
 import { find } from "lodash";

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -91,7 +91,19 @@ class App extends React.Component<AppProps, AppState> {
         } else if (userTrajectoryUrl) {
             fetch(userTrajectoryUrl as string)
                 .then((data) => data.json())
-                .then(console.log);
+                .then((json) => {
+                    const urlSplit = userTrajectoryUrl.split("/");
+                    const name = urlSplit[urlSplit.length - 1];
+                    console.log(name);
+                    changeToLocalSimulariumFile(
+                        {
+                            name, //TODO: add this to metadata about the file
+                            data: json,
+                            lastModified: Date.now(), //TODO: add this to metadata about the file
+                        },
+                        controller
+                    );
+                });
         } else {
             setSimulariumController(controller);
         }

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -77,9 +77,17 @@ class App extends React.Component<AppProps, AppState> {
         const parsed = queryString.parse(location.search);
         const fileName = parsed[URL_PARAM_KEY_FILE_NAME];
         const userTrajectoryUrl = parsed[URL_PARAM_KEY_USER_URL];
-        const networkedFile = find(TRAJECTORIES, { id: fileName });
         const controller = simulariumController || new SimulariumController({});
-        if (fileName && networkedFile) {
+        if (fileName) {
+            const networkedFile = find(TRAJECTORIES, { id: fileName });
+            if (!networkedFile) {
+                history.replaceState(
+                    {},
+                    "",
+                    `${location.origin}${location.pathname}`
+                );
+                setSimulariumController(controller);
+            }
             const fileData = networkedFile as TrajectoryDisplayData;
             // simularium controller will get initialize in the change file logic
             changeToNetworkedFile(

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -24,13 +24,14 @@ import {
     RequestLocalFileAction,
     RequestNetworkFileAction,
     SetSimulariumControllerAction,
+    SetViewerStatusAction,
 } from "../../state/metadata/types";
 import ViewerOverlayTarget from "../../components/ViewerOverlayTarget";
 import {
     DragOverViewerAction,
     ResetDragOverViewerAction,
 } from "../../state/selection/types";
-import { VIEWER_LOADING } from "../../state/metadata/constants";
+import { VIEWER_ERROR, VIEWER_LOADING } from "../../state/metadata/constants";
 import TRAJECTORIES from "../../constants/networked-trajectories";
 import { TrajectoryDisplayData } from "../../constants/interfaces";
 import { urlCheck } from "../../util";
@@ -50,6 +51,7 @@ interface AppProps {
     resetDragOverViewer: ActionCreator<ResetDragOverViewerAction>;
     viewerStatus: string;
     loadViaUrl: ActionCreator<LoadViaUrlAction>;
+    setViewerStatus: ActionCreator<SetViewerStatusAction>;
 }
 
 interface AppState {
@@ -73,6 +75,7 @@ class App extends React.Component<AppProps, AppState> {
             changeToNetworkedFile,
             simulariumController,
             loadViaUrl,
+            setViewerStatus,
         } = this.props;
         const current = this.interactiveContent.current;
 
@@ -103,17 +106,18 @@ class App extends React.Component<AppProps, AppState> {
             const verifiedUrl = urlCheck(userTrajectoryUrl);
             // if the url doesn't pass the regEx check, notify the user and then clear the url
             if (!verifiedUrl) {
-                notification.error({
-                    message: `${userTrajectoryUrl} does not seem like a url`,
-                    description:
+                console.log("Not verified url");
+                setViewerStatus({
+                    status: VIEWER_ERROR,
+                    errorMessage: `${userTrajectoryUrl} does not seem like a url`,
+                    htmlData:
                         "make sure to include 'http/https' at the beginning of the url, and check for typos",
-                    onClose: () => {
+                    onClose: () =>
                         history.replaceState(
                             {},
                             "",
                             `${location.origin}${location.pathname}`
-                        );
-                    },
+                        ),
                 });
                 setSimulariumController(controller);
                 return;
@@ -221,6 +225,7 @@ const dispatchToPropsMap = {
     resetDragOverViewer: selectionStateBranch.actions.resetDragOverViewer,
     dragOverViewer: selectionStateBranch.actions.dragOverViewer,
     loadViaUrl: metadataStateBranch.actions.loadViaUrl,
+    setViewerStatus: metadataStateBranch.actions.setViewerStatus,
 };
 
 export default connect(

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -14,7 +14,10 @@ import { State } from "../../state/types";
 
 import metadataStateBranch from "../../state/metadata";
 import selectionStateBranch from "../../state/selection";
-import { URL_PARAM_KEY_FILE_NAME } from "../../constants";
+import {
+    URL_PARAM_KEY_FILE_NAME,
+    URL_PARAM_KEY_USER_URL,
+} from "../../constants";
 import {
     LocalSimFile,
     RequestLocalFileAction,
@@ -66,15 +69,17 @@ class App extends React.Component<AppProps, AppState> {
             setSimulariumController,
             changeToNetworkedFile,
             simulariumController,
+            changeToLocalSimulariumFile,
         } = this.props;
         const current = this.interactiveContent.current;
 
         const parsed = queryString.parse(location.search);
         const fileName = parsed[URL_PARAM_KEY_FILE_NAME];
-        const file = find(TRAJECTORIES, { id: fileName });
+        const userTrajectoryUrl = parsed[URL_PARAM_KEY_USER_URL];
+        const networkedFile = find(TRAJECTORIES, { id: fileName });
         const controller = simulariumController || new SimulariumController({});
-        if (fileName && file) {
-            const fileData = file as TrajectoryDisplayData;
+        if (fileName && networkedFile) {
+            const fileData = networkedFile as TrajectoryDisplayData;
             // simularium controller will get initialize in the change file logic
             changeToNetworkedFile(
                 {
@@ -83,6 +88,10 @@ class App extends React.Component<AppProps, AppState> {
                 },
                 controller
             );
+        } else if (userTrajectoryUrl) {
+            fetch(userTrajectoryUrl as string)
+                .then((data) => data.json())
+                .then(console.log);
         } else {
             setSimulariumController(controller);
         }

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -32,6 +32,7 @@ import {
 import { VIEWER_LOADING } from "../../state/metadata/constants";
 import TRAJECTORIES from "../../constants/networked-trajectories";
 import { TrajectoryDisplayData } from "../../constants/interfaces";
+import { urlCheck } from "../../util";
 const { Content } = Layout;
 
 const styles = require("./style.css");
@@ -75,7 +76,7 @@ class App extends React.Component<AppProps, AppState> {
 
         const parsed = queryString.parse(location.search);
         const fileName = parsed[URL_PARAM_KEY_FILE_NAME];
-        const userTrajectoryUrl = parsed[URL_PARAM_KEY_USER_URL];
+        const userTrajectoryUrl = urlCheck(parsed[URL_PARAM_KEY_USER_URL]);
         const networkedFile = find(TRAJECTORIES, { id: fileName });
         const controller = simulariumController || new SimulariumController({});
         if (fileName && networkedFile) {
@@ -89,7 +90,8 @@ class App extends React.Component<AppProps, AppState> {
                 controller
             );
         } else if (userTrajectoryUrl) {
-            fetch(userTrajectoryUrl as string)
+            console.log(userTrajectoryUrl);
+            fetch(userTrajectoryUrl)
                 .then((data) => data.json())
                 .then((json) => {
                     const urlSplit = userTrajectoryUrl.split("/");

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -9,7 +9,7 @@ import "@aics/simularium-viewer/style/style.css";
 import { TrajectoryFileInfo } from "@aics/simularium-viewer/type-declarations/simularium";
 import { TimeData } from "@aics/simularium-viewer/type-declarations/viewport";
 import { connect } from "react-redux";
-import { notification, Modal } from "antd";
+import { Modal } from "antd";
 import Bowser from "bowser";
 const si = require("si-prefix");
 

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -36,7 +36,6 @@ import { batchActions } from "../../state/util";
 import PlaybackControls from "../../components/PlaybackControls";
 import CameraControls from "../../components/CameraControls";
 import ScaleBar from "../../components/ScaleBar";
-import { convertToSentenceCase } from "../../util";
 import { TUTORIAL_PATHNAME } from "../../routes";
 
 import {
@@ -45,6 +44,7 @@ import {
     getSelectionStateInfoForViewer,
 } from "./selectors";
 import { AGENT_COLORS } from "./constants";
+import errorNotification from "../../components/ErrorNotification";
 
 const styles = require("./style.css");
 
@@ -116,6 +116,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
     }
 
     public componentDidMount() {
+        const { viewerError } = this.props;
         const browser = Bowser.getParser(window.navigator.userAgent);
         // Versions from https://caniuse.com/webgl2
         const isBrowserSupported = browser.satisfies({
@@ -154,6 +155,14 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
                 this.resize(current);
             }, 200);
         }
+
+        if (viewerError) {
+            return errorNotification({
+                message: viewerError.message,
+                htmlData: viewerError.htmlData,
+                onClose: viewerError.onClose,
+            });
+        }
     }
 
     public componentDidUpdate(prevProps: ViewerPanelProps) {
@@ -164,17 +173,10 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             prevProps.viewerStatus !== VIEWER_ERROR &&
             viewerError.message
         ) {
-            notification.error({
-                message: convertToSentenceCase(viewerError.message),
-                description:
-                    (
-                        <div
-                            dangerouslySetInnerHTML={{
-                                __html: viewerError.htmlData as string,
-                            }}
-                        />
-                    ) || "",
-                duration: viewerError.htmlData ? 0 : 4.5,
+            return errorNotification({
+                message: viewerError.message,
+                htmlData: viewerError.htmlData,
+                onClose: viewerError.onClose,
             });
         }
         if (

--- a/src/state/metadata/actions.ts
+++ b/src/state/metadata/actions.ts
@@ -10,6 +10,7 @@ import {
     LOAD_NETWORKED_FILE_IN_VIEWER,
     REQUEST_PLOT_DATA,
     CLEAR_SIMULARIUM_FILE,
+    LOAD_FILE_VIA_URL,
 } from "./constants";
 import {
     MetadataStateBranch,
@@ -24,6 +25,7 @@ import {
     RequestNetworkFileAction,
     RequestLocalFileAction,
     ClearSimFileDataAction,
+    LoadViaUrlAction,
 } from "./types";
 import { SimulariumController } from "@aics/simularium-viewer/type-declarations";
 
@@ -122,5 +124,16 @@ export function setViewerStatus(
     return {
         payload,
         type: SET_VIEWER_STATUS,
+    };
+}
+
+export function loadViaUrl(
+    payload: string,
+    controller?: SimulariumController
+): LoadViaUrlAction {
+    return {
+        payload,
+        controller,
+        type: LOAD_FILE_VIA_URL,
     };
 }

--- a/src/state/metadata/actions.ts
+++ b/src/state/metadata/actions.ts
@@ -77,10 +77,12 @@ export function receiveAgentNamesAndStates(
 }
 
 export function changeToLocalSimulariumFile(
-    payload: LocalSimFile
+    payload: LocalSimFile,
+    controller?: SimulariumController
 ): RequestLocalFileAction {
     return {
         payload,
+        controller,
         type: LOAD_LOCAL_FILE_IN_VIEWER,
     };
 }

--- a/src/state/metadata/constants.ts
+++ b/src/state/metadata/constants.ts
@@ -22,6 +22,7 @@ export const LOAD_NETWORKED_FILE_IN_VIEWER = makeMetadataConstant(
 );
 export const REQUEST_PLOT_DATA = makeMetadataConstant("request-plot-data");
 export const CLEAR_SIMULARIUM_FILE = makeMetadataConstant("clear-sim-file");
+export const LOAD_FILE_VIA_URL = makeMetadataConstant("load-file-via-url");
 
 export const VIEWER_EMPTY = "empty";
 export const VIEWER_LOADING = "loading";

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -254,6 +254,7 @@ const loadFileViaUrl = createLogic({
                         simulariumController
                     )
                 );
+                done();
             })
             .catch((error) => {
                 dispatch(

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -174,7 +174,14 @@ const loadLocalFile = createLogic({
     process(deps: ReduxLogicDeps, dispatch, done) {
         const { action, getState } = deps;
         const currentState = getState();
-        const simulariumController = getSimulariumController(currentState);
+        let simulariumController = getSimulariumController(currentState);
+        console.log(action.controller);
+        if (!simulariumController) {
+            if (action.controller) {
+                simulariumController = action.controller;
+                dispatch(setSimulariumController(simulariumController));
+            }
+        }
         const lastSimulariumFile: LocalSimFile = getSimulariumFile(
             currentState
         );

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -178,7 +178,6 @@ const loadLocalFile = createLogic({
         const currentState = getState();
         const simulariumController =
             getSimulariumController(currentState) || action.controller;
-        console.log(simulariumController);
         const lastSimulariumFile: LocalSimFile = getSimulariumFile(
             currentState
         );

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -261,7 +261,7 @@ const loadFileViaUrl = createLogic({
                     setViewerStatus({
                         status: VIEWER_ERROR,
                         errorMessage: error.message,
-                        htmlData: `${url} failed` || "",
+                        htmlData: `${url} failed`,
                         onClose: () =>
                             history.replaceState(
                                 {},

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -261,6 +261,12 @@ const loadFileViaUrl = createLogic({
                         status: VIEWER_ERROR,
                         errorMessage: error.message,
                         htmlData: `${url} failed` || "",
+                        onClose: () =>
+                            history.replaceState(
+                                {},
+                                "",
+                                `${location.origin}${location.pathname}`
+                            ),
                     })
                 );
                 done();

--- a/src/state/metadata/reducer.ts
+++ b/src/state/metadata/reducer.ts
@@ -101,6 +101,7 @@ const actionToConfigMap: TypeToDescriptionMap = {
                     ? {
                           message: action.payload.errorMessage,
                           htmlData: action.payload.htmlData,
+                          onClose: action.payload.onClose,
                       }
                     : "",
         }),

--- a/src/state/metadata/types.ts
+++ b/src/state/metadata/types.ts
@@ -92,11 +92,13 @@ export interface ViewerStatusInfo {
     htmlData?: string;
     errorMessage?: string;
     status: ViewerStatus;
+    onClose?: () => void;
 }
 
 export interface ViewerError {
     htmlData?: string;
     message: string;
+    onClose?: () => void;
 }
 
 export interface FrontEndError extends Error {

--- a/src/state/metadata/types.ts
+++ b/src/state/metadata/types.ts
@@ -46,6 +46,12 @@ export interface RequestLocalFileAction {
     controller?: SimulariumController;
 }
 
+export interface LoadViaUrlAction {
+    payload: string;
+    type: string;
+    controller?: SimulariumController;
+}
+
 export interface LocalSimFile {
     name: string;
     data: SimulariumFileFormat;

--- a/src/state/metadata/types.ts
+++ b/src/state/metadata/types.ts
@@ -43,6 +43,7 @@ export interface RequestNetworkFileAction {
 export interface RequestLocalFileAction {
     payload: LocalSimFile;
     type: string;
+    controller?: SimulariumController;
 }
 
 export interface LocalSimFile {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -83,7 +83,7 @@ export const urlCheck = (urlToCheck: any): string => {
      * and I made the http(s) required
      */
     const regEx = /(https?:\/\/)([\w\-]){0,200}(\.[a-zA-Z][^\-])([\/\w]*)*\/?\??([^\n\r]*)??([^\n\r]*)/g;
-    if (!!urlToCheck.match(regEx)) {
+    if (regEx.test(urlToCheck)) {
         return urlToCheck;
     }
     return "";

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -77,6 +77,11 @@ export const urlCheck = (urlToCheck: any): string => {
     if (typeof urlToCheck !== "string") {
         return "";
     }
+    /**
+     * RegEx: https://regexr.com/5pkui, forked from https://regexr.com/39p0t
+     * I had to modify the original to allow s3 buckets which have multiple `.letters-letters.` in them
+     * and I made the http(s) required
+     */
     const regEx = /(https?:\/\/)([\w\-]){0,200}(\.[a-zA-Z][^\-])([\/\w]*)*\/?\??([^\n\r]*)??([^\n\r]*)/g;
     if (!!urlToCheck.match(regEx)) {
         return urlToCheck;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -74,12 +74,10 @@ export const wrapText = (
 };
 
 export const urlCheck = (urlToCheck: any): string => {
-    console.log(typeof urlToCheck);
     if (typeof urlToCheck !== "string") {
         return "";
     }
     const regEx = /(https?:\/\/)([\w\-]){0,200}(\.[a-zA-Z][^\-])([\/\w]*)*\/?\??([^\n\r]*)??([^\n\r]*)/g;
-    console.log(urlToCheck, urlToCheck.match(regEx));
     if (!!urlToCheck.match(regEx)) {
         return urlToCheck;
     }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -72,3 +72,16 @@ export const wrapText = (
         numLines: numLines,
     };
 };
+
+export const urlCheck = (urlToCheck: any): string => {
+    console.log(typeof urlToCheck);
+    if (typeof urlToCheck !== "string") {
+        return "";
+    }
+    const regEx = /(https?:\/\/)([\w\-]){0,200}(\.[a-zA-Z][^\-])([\/\w]*)*\/?\??([^\n\r]*)??([^\n\r]*)/g;
+    console.log(urlToCheck, urlToCheck.match(regEx));
+    if (!!urlToCheck.match(regEx)) {
+        return urlToCheck;
+    }
+    return "";
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -83,3 +83,7 @@ export const urlCheck = (urlToCheck: any): string => {
     }
     return "";
 };
+
+export const clearUrlParams = () => {
+    history.replaceState({}, "", `${location.origin}${location.pathname}`);
+};

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import * as React from "react";
 
-import { bindAll, convertToSentenceCase, wrapText } from "../";
+import { bindAll, convertToSentenceCase, urlCheck, wrapText } from "../";
 
 describe("General utilities", () => {
     describe("bindAll", () => {
@@ -95,6 +95,40 @@ describe("General utilities", () => {
                 formattedText: "123 567<br>890<br>abcdefg<br>wxyz",
                 numLines: 4,
             });
+        });
+    });
+    describe("urlCheck", () => {
+        it("returns strings that match the regex", () => {
+            const shouldMatch = [
+                "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium",
+                "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.json",
+                "http://web5-site.com/directory",
+                "https://fa-st.web9site.com/directory/file.filename",
+                "https://fa-st.web9site.com/directory-name/file.filename",
+                "https://website.com/directory/?key=val",
+                "http://www.website.com/?key=val#anchor",
+            ];
+            const result = shouldMatch.map(urlCheck);
+            expect(result).to.deep.equal(shouldMatch);
+        });
+        it("returns an empty string if give a non string", () => {
+            const shouldNotMatch = [[], {}, 2, null, undefined];
+            const result = shouldNotMatch.map(urlCheck);
+            expect(result).to.deep.equal(Array(shouldNotMatch.length).fill(""));
+        });
+        it("returns an empty string if the given string is not an accepted url", () => {
+            const shouldNotMatch = [
+                "website.com/?querystring",
+                "www.website.com/?key=val",
+                "http://website.c-om/directory",
+                "https://website",
+                "fast..web9site.com/directory/file.filename",
+                "web?site.com",
+                "website...com/??querystring",
+                "www.w;ebsite.?com/",
+            ];
+            const result = shouldNotMatch.map(urlCheck);
+            expect(result).to.deep.equal(Array(shouldNotMatch.length).fill(""));
         });
     });
 });


### PR DESCRIPTION
Problem
=======
Users want to be able to share a link to their own trajectory data [AGENTVIZ-1351](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1351)

Solution
========
1. users can link to a simularium file hosted somewhere (like s3) by using a query param in the url: `trajUrl=`
2. If someone provides a url that isn't formatted correctly, the error message will popup and the url will be cleared out
3. If someone provides a url that returns a 404, the error message will popup and the url will be cleared out. 

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires updated or new tests

Change summary:
---------------
* added a new logic for "load via url" that calls the load local file logic
* added checks for url formatting, and additional error reporting
* added tests for passing/not passing urls so we can be clear why something fails
*

Steps to Verify:
----------------
Once you have it running locally:
1. Working example: http://localhost:9001/viewer?trajUrl=https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium
1. To see malformed url error: http://localhost:9001/viewer?trajUrl=//aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium
1. To see 404 error: http://localhost:9001/viewer?trajUrl=https://not-a-real-url.com


Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Thanks for contributing!
