### PR TITLE
Feature/only work with 1 type interface for TrajectoryFileInfo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aics/simularium-observables-manager": "^0.1.0",
-        "@aics/simularium-viewer": "^2.7.0",
+        "@aics/simularium-viewer": "^2.7.1",
         "@ant-design/css-animation": "^1.7.3",
         "@ant-design/icons": "^4.0.6",
         "@types/react-plotly.js": "^2.2.4",
@@ -98,6 +98,65 @@
         "webpack-dev-server": "^3.11.0"
       }
     },
+    "../simularium-viewer": {
+      "name": "@aics/simularium-viewer",
+      "version": "2.7.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-free": "^5.15.2",
+        "@fortawesome/fontawesome-svg-core": "^1.2.34",
+        "@fortawesome/free-solid-svg-icons": "^5.15.2",
+        "@fortawesome/react-fontawesome": "^0.1.14",
+        "comlink": "^4.3.0",
+        "dat.gui": "^0.7.6",
+        "js-logger": "^1.6.1",
+        "parse-pdb": "^1.0.0",
+        "react": "~16.9.0",
+        "react-dom": "^16.9.0",
+        "three": "^0.125.2"
+      },
+      "devDependencies": {
+        "@babel/cli": "~7.2",
+        "@babel/core": "^7.12.13",
+        "@babel/plugin-proposal-class-properties": "^7.12.13",
+        "@babel/preset-env": "~7.3",
+        "@babel/preset-react": "^7.12.13",
+        "@babel/preset-typescript": "~7.1",
+        "@types/jest": "^26.0.20",
+        "@types/lodash": "^4.14.168",
+        "@types/react": "^16.14.3",
+        "@typescript-eslint/eslint-plugin": "~3.4.0",
+        "@typescript-eslint/parser": "~3.4.0",
+        "babel-loader": "~8.0",
+        "babel-plugin-const-enum": "^1.0.1",
+        "copy-webpack-plugin": "~5.0.4",
+        "css-loader": "^3.2.0",
+        "cssnano": "^4.1.10",
+        "eslint": "^7.19.0",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-plugin-react": "^7.22.0",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^1.3.1",
+        "jest": "^26.6.3",
+        "lint-staged": "^8.1.0",
+        "mini-css-extract-plugin": "^0.8.0",
+        "npm-run-all": "^4.1.5",
+        "nyc": "~15.0",
+        "postcss": "^7.0.17",
+        "postcss-cli": "^6.1.3",
+        "postcss-preset-env": "^6.7.0",
+        "prettier": "^2.2.1",
+        "rimraf": "~2.6",
+        "ts-jest": "^26.5.0",
+        "ts-node": "~8.10.2",
+        "typescript": "~3.9.5",
+        "webpack": "~4.29",
+        "webpack-cli": "^3.3.12",
+        "webpack-dev-server": "^3.11.2",
+        "worker-loader": "^2.0.0"
+      }
+    },
     "node_modules/@aics/simularium-observables-manager": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@aics/simularium-observables-manager/-/simularium-observables-manager-0.1.0.tgz",
@@ -108,9 +167,9 @@
       }
     },
     "node_modules/@aics/simularium-viewer": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.7.0.tgz",
-      "integrity": "sha512-hzgV3ofdCttAM7Rd+lCTxDYZ8P+am6akezW/xOoJ53DCFi3FQdh8s+29vcAFY7YnBCD350EysrbF3aDMxcPEoA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.7.1.tgz",
+      "integrity": "sha512-TOgv8GzpnZiw7oXDItC+Arfs8tyCEXkGrpbdFygDUMtr7PHjQcC5u3VUjEIAP6X+nniDwtrCqaQoYQath6RNJQ==",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.34",
@@ -18826,9 +18885,9 @@
       "integrity": "sha512-7G9LM9v3lpEA0xNNPWyceZqRxjiBlP27rMvfosAZcIe5ASVZaotbyjVOWmaFttySgTYtk8W/cKU1AHNHkJpQTA=="
     },
     "@aics/simularium-viewer": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.7.0.tgz",
-      "integrity": "sha512-hzgV3ofdCttAM7Rd+lCTxDYZ8P+am6akezW/xOoJ53DCFi3FQdh8s+29vcAFY7YnBCD350EysrbF3aDMxcPEoA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.7.1.tgz",
+      "integrity": "sha512-TOgv8GzpnZiw7oXDItC+Arfs8tyCEXkGrpbdFygDUMtr7PHjQcC5u3VUjEIAP6X+nniDwtrCqaQoYQath6RNJQ==",
       "requires": {
         "@fortawesome/fontawesome-free": "^5.15.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.34",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@aics/simularium-observables-manager": "^0.1.0",
-    "@aics/simularium-viewer": "^2.7.0",
+    "@aics/simularium-viewer": "^2.7.1",
     "@ant-design/css-animation": "^1.7.3",
     "@ant-design/icons": "^4.0.6",
     "@types/react-plotly.js": "^2.2.4",

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -6,10 +6,7 @@ import SimulariumViewer, {
     SelectionStateInfo,
 } from "@aics/simularium-viewer";
 import "@aics/simularium-viewer/style/style.css";
-import {
-    TrajectoryFileInfo,
-    TrajectoryFileInfoV2,
-} from "@aics/simularium-viewer/type-declarations/simularium";
+import { TrajectoryFileInfo } from "@aics/simularium-viewer/type-declarations/simularium";
 import { TimeData } from "@aics/simularium-viewer/type-declarations/viewport";
 import { connect } from "react-redux";
 import { Modal } from "antd";
@@ -239,18 +236,16 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
 
     public onTrajectoryFileInfoChanged(data: TrajectoryFileInfo) {
         const { receiveMetadata, simulariumController } = this.props;
-        const updatedData = data as TrajectoryFileInfoV2;
         const tickIntervalLength = simulariumController.tickIntervalLength;
 
         const scaleBarLabelNumber =
-            tickIntervalLength * updatedData.spatialUnits.magnitude;
-        const scaleBarLabelUnit = updatedData.spatialUnits.name;
+            tickIntervalLength * data.spatialUnits.magnitude;
+        const scaleBarLabelUnit = data.spatialUnits.name;
 
         receiveMetadata({
-            numFrames: updatedData.totalSteps,
-            timeStepSize:
-                updatedData.timeStepSize * updatedData.timeUnits.magnitude,
-            timeUnits: updatedData.timeUnits,
+            numFrames: data.totalSteps,
+            timeStepSize: data.timeStepSize * data.timeUnits.magnitude,
+            timeUnits: data.timeUnits,
         });
 
         this.setState({


### PR DESCRIPTION
Problem
=======
* simularium-website was still working with multiple type interfaces for TrajectoryFileInfo (`TrajectoryFileInfo` and `TrajectoryFileInfoV2`) even though only the updated version was being fed to it.
* Addresses part 2 of
[updateTrajectoryFileInfoFormat's return type should be the latest version of TrajectoryFileInfo](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1382) and closes it out

Solution
========
* Updated simularium-viewer version to 2.7.1 which only exports the type interface `TrajectoryFileInfo` which now is always the latest version

## Type of change
Non-breaking change with no change to the UI (just refactoring)

Steps to Verify:
----------------
1. `npm i` then `npm start`, verify everything works like before with local and networked trajectories (minus separate issues we have with networked trajectories currently)
