### PR TITLE
Fix/ not being able to step to last frame

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aics/simularium-observables-manager": "^0.1.0",
-        "@aics/simularium-viewer": "^2.7.3",
+        "@aics/simularium-viewer": "^2.7.4",
         "@ant-design/css-animation": "^1.7.3",
         "@ant-design/icons": "^4.0.6",
         "@types/react-plotly.js": "^2.2.4",
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@aics/simularium-viewer": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.7.3.tgz",
-      "integrity": "sha512-C2mE62ou3zGs9j5ryT0gqBAR/Ys4UiU0kbuATExaXLAm6WNkEkj1MoNmrlElzXTQd26aMJD0nr2KmFmjU8N9tA==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.7.4.tgz",
+      "integrity": "sha512-zEgGukdrID66dsxdN9r/gNHdLvUCLYFt8Is6JAYntqErCoivkeX4FQk0LzYq7fO/ZJaxkWKdRPkvBN6NiPKeFg==",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.34",
@@ -17427,9 +17427,9 @@
       "version": "0.1.0"
     },
     "@aics/simularium-viewer": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.7.3.tgz",
-      "integrity": "sha512-C2mE62ou3zGs9j5ryT0gqBAR/Ys4UiU0kbuATExaXLAm6WNkEkj1MoNmrlElzXTQd26aMJD0nr2KmFmjU8N9tA==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.7.4.tgz",
+      "integrity": "sha512-zEgGukdrID66dsxdN9r/gNHdLvUCLYFt8Is6JAYntqErCoivkeX4FQk0LzYq7fO/ZJaxkWKdRPkvBN6NiPKeFg==",
       "requires": {
         "@fortawesome/fontawesome-free": "^5.15.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.34",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@aics/simularium-observables-manager": "^0.1.0",
-    "@aics/simularium-viewer": "^2.7.3",
+    "@aics/simularium-viewer": "^2.7.4",
     "@ant-design/css-animation": "^1.7.3",
     "@ant-design/icons": "^4.0.6",
     "@types/react-plotly.js": "^2.2.4",

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -128,7 +128,7 @@ const PlayBackControls = ({
                     ])}
                     size="small"
                     onClick={nextHandler}
-                    disabled={time + timeStep >= lastFrameTime || loading}
+                    disabled={time + timeStep > lastFrameTime || loading}
                     loading={loading}
                 >
                     {/* if loading, antd will show loading icon, otherwise, show our custom svg */}

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -299,7 +299,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         if (isBuffering) {
             return;
         }
-        if (time >= lastFrameTime) {
+        if (time > lastFrameTime) {
             return;
         }
 


### PR DESCRIPTION
Problem
=======
Once I am at the second-to-the-last frame, the "skip 1 frame ahead" button gets disabled and I can't get to the last frame.

Resolves (along with the [changes recently merged to simularium-viewer](https://github.com/allen-cell-animated/simularium-viewer/pull/106)): [viewer won't step to last time frame](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1357)

Solution
========
* Updated simularium-viewer to the latest version which contains the necessary internal changes for fixing this bug
* Tweaked the Skip 1 Frame button in src/components/PlaybackControls/index.tsx so that it's not prematurely disabled
* Tweaked `skipToTime()` in src/containers/ViewerPanel/index.tsx (which is indirectly called when the Skip 1 Frame button is clicked) so that the function doesn't just return when the target time is the last frame time

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Clone this branch down, `npm i` then `npm start`, then drag and drop the example 3-frame trajectory from the Jira issue above into the viewer (you can test with any trajectory but it's way easier with this 3-framer)
2. Click the skip frame button until you get to the final frame. Ta-da
