### PR TITLE
Fix/round scale bar label

### DIFF
--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -238,8 +238,9 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         const { receiveMetadata, simulariumController } = this.props;
         const tickIntervalLength = simulariumController.tickIntervalLength;
 
-        const scaleBarLabelNumber =
+        let scaleBarLabelNumber =
             tickIntervalLength * data.spatialUnits.magnitude;
+        scaleBarLabelNumber = parseFloat(scaleBarLabelNumber.toPrecision(2));
         const scaleBarLabelUnit = data.spatialUnits.name;
 
         receiveMetadata({


### PR DESCRIPTION
Problem
=======
Networked trajectories on staging shows scale bar labels like "99.99999939225 nm"

Solution
========
I rounded the number to 2 sig figs like we were doing previously.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
Can't verify the fix locally at this moment because networked trajectories aren't loading to dev but I'm sure this will fix it 😆 
