### PR TITLE
Fix/slider freezing issues

### DIFF
--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -87,7 +87,9 @@ const PlayBackControls = ({
                     ])}
                     size="small"
                     onClick={prevHandler}
-                    disabled={time === firstFrameTime || loading}
+                    disabled={
+                        time - timeStep < firstFrameTime || loading || isEmpty
+                    }
                     loading={loading}
                 >
                     {/* if loading, antd will show loading icon, otherwise, show our custom svg */}
@@ -128,7 +130,9 @@ const PlayBackControls = ({
                     ])}
                     size="small"
                     onClick={nextHandler}
-                    disabled={time + timeStep > lastFrameTime || loading}
+                    disabled={
+                        time + timeStep > lastFrameTime || loading || isEmpty
+                    }
                     loading={loading}
                 >
                     {/* if loading, antd will show loading icon, otherwise, show our custom svg */}

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -292,6 +292,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
     public skipToTime(time: number) {
         const {
             simulariumController,
+            firstFrameTime,
             lastFrameTime,
             isBuffering,
             setBuffering,
@@ -299,7 +300,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         if (isBuffering) {
             return;
         }
-        if (time > lastFrameTime) {
+        if (time > lastFrameTime || time < firstFrameTime) {
             return;
         }
 

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -300,7 +300,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         if (isBuffering) {
             return;
         }
-        const roundedTime = parseFloat(time.toFixed(4));
+        const roundedTime = parseFloat(time.toPrecision(4));
         if (roundedTime > lastFrameTime || roundedTime < firstFrameTime) {
             return;
         }

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -300,12 +300,13 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         if (isBuffering) {
             return;
         }
-        if (time > lastFrameTime || time < firstFrameTime) {
+        const roundedTime = parseFloat(time.toFixed(4));
+        if (roundedTime > lastFrameTime || roundedTime < firstFrameTime) {
             return;
         }
 
         setBuffering(true);
-        simulariumController.gotoTime(time);
+        simulariumController.gotoTime(roundedTime);
     }
 
     public handleUiDisplayDataChanged = (uiData: UIDisplayData) => {


### PR DESCRIPTION
Problem
=======
Resolves: [scrubbing time breaks viewer](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1367)

Actually, I think the specific problems described in the above issue (scrubbing sometimes freezes slider, stepping forward sometimes freezes slider) went away after #119 was merged, but instead, stepping backward started to sometimes freeze the slider. I think they're all sort of the same problem though.

Solution
========
I noticed a weird pattern while stepping back and forth with the Next/Previous Frame buttons in the simularium-viewer test site. Sometimes when you step forward, the time values would go something like 0.1 -> 0.15000000000000000002 -> 0.2 and then when you step back, it would be 0.2 -> 0.1 instead of 0.2 -> 0.15000000000000000002 -> 0.1. And this would break the slider. [When I rounded the time values to 4 sig figs in the test viewer](https://github.com/allen-cell-animated/simularium-viewer/pull/107) this problem went away. So I applied the same fix to the `ViewerPanel` component here in simularium-website and I haven't been able to reproduce any slider bugs since.

I also went through and made any code having to do with stepping back 1 frame mirror the code having to do with stepping forward 1 frame.

Bonus fix: I made the step frame buttons disabled when the viewer is empty, because when you click on them with no trajectory loaded it'll freeze the viewer.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Pull this branch,
2. Drag and drop a file (networked trajectories on dev aren't working at this time)
3. Step frames back and forth and scrub to your heart's content and see if the viewer freezes (it shouldn't)
