### PR TITLE
Feature/version number badges

### DIFF
--- a/src/components/ModelCard/index.tsx
+++ b/src/components/ModelCard/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Card } from "antd";
+import { Card, Tag } from "antd";
 import { Link } from "react-router-dom";
 
 import { URL_PARAM_KEY_FILE_NAME } from "../../constants";
@@ -54,7 +54,12 @@ const ModelCard: React.FunctionComponent<ModelCardProps> = (
             }
         >
             <div className={styles.cardText}>
-                <p className={styles.simulatedTime}>{totalSimulatedTime}</p>
+                <p className={styles.versionAndTime}>
+                    <Tag className={styles.versionTag}>f</Tag>
+                    <div className={styles.simulatedTime}>
+                        {totalSimulatedTime}
+                    </div>
+                </p>
                 <Link
                     to={{
                         pathname: VIEWER_PATHNAME,

--- a/src/components/ModelCard/index.tsx
+++ b/src/components/ModelCard/index.tsx
@@ -19,6 +19,7 @@ const ModelCard: React.FunctionComponent<ModelCardProps> = (
         id,
         title,
         totalSimulatedTime,
+        version,
         authors,
         publication,
         description,
@@ -55,10 +56,14 @@ const ModelCard: React.FunctionComponent<ModelCardProps> = (
         >
             <div className={styles.cardText}>
                 <p className={styles.versionAndTime}>
-                    <Tag className={styles.versionTag}>f</Tag>
-                    <div className={styles.simulatedTime}>
+                    {version ? (
+                        <div className={styles.versionTag}>v{version}</div>
+                    ) : (
+                        <div />
+                    )}
+                    <span className={styles.simulatedTime}>
                         {totalSimulatedTime}
-                    </div>
+                    </span>
                 </p>
                 <Link
                     to={{

--- a/src/components/ModelCard/index.tsx
+++ b/src/components/ModelCard/index.tsx
@@ -57,7 +57,7 @@ const ModelCard: React.FunctionComponent<ModelCardProps> = (
             <div className={styles.cardText}>
                 <p className={styles.versionAndTime}>
                     {version ? (
-                        <div className={styles.versionTag}>v{version}</div>
+                        <Tag className={styles.versionTag}>v{version}</Tag>
                     ) : (
                         <div />
                     )}

--- a/src/components/ModelCard/style.css
+++ b/src/components/ModelCard/style.css
@@ -43,8 +43,7 @@
     height: 20px;
     font-size: 16px;
     color: white;
-    border-color: var(--light-theme-card-version-tag-purple);
-    background-color: var(--light-theme-card-version-tag-purple);
+    border-color: var(--light-theme-version-badge-purple);
 }
 
 .version-tag:hover {

--- a/src/components/ModelCard/style.css
+++ b/src/components/ModelCard/style.css
@@ -32,6 +32,7 @@
     font-size: 16px;
 }
 
+/* Necessary to make flexbox spacing work */
 .version-tag, .simulated-time {
     margin: 0 !important;
 }
@@ -46,6 +47,7 @@
     border-color: var(--light-theme-version-badge-purple);
 }
 
+/* Remove Antd hover effect for Tags */
 .version-tag:hover {
     opacity: 1;
 }

--- a/src/components/ModelCard/style.css
+++ b/src/components/ModelCard/style.css
@@ -36,6 +36,15 @@
     margin: 0 !important;
 }
 
+.version-tag {
+    border-radius: 2px;
+    padding-right: 5px;
+    padding-left: 5px;
+    height: 1.25em;
+    color: white;
+    background-color: var(--light-theme-card-version-tag-purple);
+}
+
 .card-title {
     font-weight: 600;
 }

--- a/src/components/ModelCard/style.css
+++ b/src/components/ModelCard/style.css
@@ -38,10 +38,12 @@
 
 .version-tag {
     border-radius: 2px;
-    padding-right: 5px;
-    padding-left: 5px;
-    height: 1.25em;
+    padding-right: 3px;
+    padding-left: 3px;
+    height: 20px;
+    font-size: 16px;
     color: white;
+    border-color: var(--light-theme-card-version-tag-purple);
     background-color: var(--light-theme-card-version-tag-purple);
 }
 

--- a/src/components/ModelCard/style.css
+++ b/src/components/ModelCard/style.css
@@ -47,6 +47,10 @@
     background-color: var(--light-theme-card-version-tag-purple);
 }
 
+.version-tag:hover {
+    opacity: 1;
+}
+
 .card-title {
     font-weight: 600;
 }

--- a/src/components/ModelCard/style.css
+++ b/src/components/ModelCard/style.css
@@ -25,10 +25,15 @@
     font-size: 16px;
 }
 
-.simulated-time {
+.version-and-time {
+    display: flex;
+    justify-content: space-between;
     margin-top: 4px;
-    text-align: right;
     font-size: 16px;
+}
+
+.version-tag, .simulated-time {
+    margin: 0 !important;
 }
 
 .card-title {

--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -2,7 +2,9 @@ import * as React from "react";
 import { useLocation } from "react-router-dom";
 import { Tag } from "antd";
 import moment from "moment";
+
 import { VIEWER_PATHNAME } from "../../routes";
+import TRAJECTORIES from "../../constants/networked-trajectories";
 
 const styles = require("./style.css");
 
@@ -22,11 +24,25 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
         ) : (
             <span />
         );
+
+    const trajectoryId = location.search.replace("?trajFileName=", "");
+    const currentTrajectory = TRAJECTORIES.find(
+        (trajectory) => trajectory.id === trajectoryId
+    );
+    const version = currentTrajectory ? currentTrajectory.version : "";
+
+    let tagText = "";
+    if (lastModified) {
+        tagText = `modified: ${moment(lastModified).format(
+            "YYYY-MM-DD, h:m A"
+        )}`;
+    } else if (version) {
+        tagText = `v${version}`;
+    }
+
     const tag =
-        location.pathname.startsWith(VIEWER_PATHNAME) && lastModified ? (
-            <Tag className={styles.tag}>
-                modified: {moment(lastModified).format("YYYY-MM-DD, h:m A")}
-            </Tag>
+        location.pathname.startsWith(VIEWER_PATHNAME) && tagText ? (
+            <Tag className={styles.tag}>{tagText}</Tag>
         ) : (
             <span />
         );

--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -25,6 +25,10 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
             <span />
         );
 
+    // Grab the trajectory ID from the URL and find the corresponding trajectory object in
+    // networked-trajectories.ts to get its version info
+    // TODO: Eventually we should put all the contents of networked-trajectories.ts in the
+    // Simularium files themselves
     const trajectoryId = location.search.replace("?trajFileName=", "");
     const currentTrajectory = TRAJECTORIES.find(
         (trajectory) => trajectory.id === trajectoryId

--- a/src/components/ViewerTitle/style.css
+++ b/src/components/ViewerTitle/style.css
@@ -7,5 +7,11 @@
 
 .tag {
     margin-left: 10px;
-    color: var(--dark-theme-text-color);
+    border-radius: 2px;
+    padding-right: 5px;
+    padding-left: 5px;
+    height: 20px;
+    font-size: 12px;
+    border-color: var(--dark-theme-version-badge-purple);
+    background-color: var(--dark-theme-version-badge-purple);
 }

--- a/src/constants/interfaces.ts
+++ b/src/constants/interfaces.ts
@@ -3,6 +3,7 @@ export interface TrajectoryDisplayData {
     id: string;
     title: string;
     subtitle?: string;
+    version?: string;
     totalSimulatedTime: string;
     authors: string;
     publication: {

--- a/src/constants/networked-trajectories.ts
+++ b/src/constants/networked-trajectories.ts
@@ -33,7 +33,8 @@ const TRAJECTORIES: TrajectoryDisplayData[] = [
     {
         modelName: "SARS-CoV-2 Dynamics in Human Lung Epithelium",
         id: "pc4covid19.simularium",
-        title: "SARS-CoV-2 Dynamics in Human Lung Epithelium (v4.1)",
+        title: "SARS-CoV-2 Dynamics in Human Lung Epithelium",
+        version: "4.1",
         totalSimulatedTime: "24h",
         authors: "Michael Getz et al.",
         publication: {

--- a/src/styles/ant-vars.less
+++ b/src/styles/ant-vars.less
@@ -8,6 +8,7 @@ https://github.com/ant-design/ant-design/blob/master/components/style/themes/def
 @white-six: #e7e7e7;
 @baby-purple: #b59ff6;
 @dark-purple: #3b3649;
+@allen-purple: #8d87aa;
 @greyish-brown: #4a4a4a;
 @highlight-green: #b2d030;
 @blue: #0094FF;
@@ -212,3 +213,7 @@ https://github.com/ant-design/ant-design/blob/master/components/style/themes/def
 @menu-dark-selected-item-icon-color: @white;
 @menu-dark-selected-item-text-color: @white;
 @menu-dark-item-hover-bg: transparent;
+
+// Tag
+@tag-default-bg: @allen-purple;
+@tag-default-color: @white-six;

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -4,6 +4,7 @@
     --dark-two: #1e1b25;
     --dark-three: #25222e;
     --dark-four: #2f2a3c;
+    --dark-five: #3c384a;
     --pure-white: #ffffff;
     --off-white: #f8f8f8;
     --white-two: #d3d3d3;
@@ -19,6 +20,7 @@
     --dark-blue-grey: #2d224d;
     --background-dark-gray: #131313;
     --baby-purple: #b59ff6;
+    --allen-purple: #8d87aa;
     --blue: #0094FF;
     --background-dim-gray: var(--dim-gray);
     --border-gray: var(--white-six);
@@ -50,6 +52,7 @@
     --dark-theme-btn-primary-text: var(--dark-two);
     --dark-theme-slider-color: var(--white-three);    
     --dark-theme-tooltip-bg: var(--dark);
+    --dark-theme-version-badge-purple: var(--dark-five);
     --light-theme-background-purple: var(--pale-grey);
     --light-theme-button-purple: var(--dark-blue-grey);
     --light-theme-heading1-gray: var(--dark-three);
@@ -57,7 +60,7 @@
     --light-theme-panel-light-gray: var(--white-four);
     --light-theme-button-light-gray: var(--white-four);
     --light-theme-card-bg-white: var(--pure-white);
-    --light-theme-card-version-tag-purple: var(--baby-purple);
+    --light-theme-version-badge-purple: var(--allen-purple);
     --light-theme-background-off-white: var(--off-white);
     --light-theme-faint-text: var(--white-two);
 }

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -57,6 +57,7 @@
     --light-theme-panel-light-gray: var(--white-four);
     --light-theme-button-light-gray: var(--white-four);
     --light-theme-card-bg-white: var(--pure-white);
+    --light-theme-card-version-tag-purple: var(--baby-purple);
     --light-theme-background-off-white: var(--off-white);
     --light-theme-faint-text: var(--white-two);
 }


### PR DESCRIPTION
Problem
=======
The authors of networked trajectory models would like an option to display a version number for the trajectory file. As a temporary measure we had added them to the title of the simulation, like "SARS-CoV-2 Dynamics in Human Lung Epithelium (v4.1)", but we want a nicer looking badge for the version number instead.

Resolves: [implement badge for version numbers of models](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1305)

Solution
========
Added version number badges as shown in the mockups (links in Jira ticket above)

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

Screenshots (optional):
-----------------------
Added badge to library card:
![image](https://user-images.githubusercontent.com/12690133/117488417-3ac98900-af21-11eb-8e83-38c7b0265e43.png)
Added badge to viewer header:
![image](https://user-images.githubusercontent.com/12690133/117488496-56cd2a80-af21-11eb-93cb-ea6308371f9f.png)
The "modified:" tag for drag-and-drop file looks more or less the same as before:
![image](https://user-images.githubusercontent.com/12690133/117488763-a3186a80-af21-11eb-8677-e397fc700be3.png)

Keyfiles (delete if not relevant):
-----------------------
1. src/components/ModelCard/index.tsx - Add badge to library card
2. src/components/ViewerTitle/index.tsx - Add badge to viewer header
3. src/constants/networked-trajectories.ts - Add version number for COVID model

Thanks for contributing!
