### PR TITLE
Feature/update simularium-viewer to 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "@aics/simularium-observables-manager": "^0.1.0",
-                "@aics/simularium-viewer": "^2.8.0",
+                "@aics/simularium-viewer": "^2.9.0",
                 "@ant-design/css-animation": "^1.7.3",
                 "@ant-design/icons": "^4.0.6",
                 "@types/react-plotly.js": "^2.2.4",
@@ -107,9 +107,9 @@
             }
         },
         "node_modules/@aics/simularium-viewer": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.8.0.tgz",
-            "integrity": "sha512-u9Wkk7nAwP3bdv9FM9cmx7O15NyEdpU/xMc3/zcP4ck43CuC+zRmiCBoeWwhlQNxrJRsTgbfaMg/dr/SEuN4+Q==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.9.0.tgz",
+            "integrity": "sha512-T9a85XX881mcl0tXWA0MnFZypbPN9PnksLaq40TORxfArMT298GdfjUd0sOsXZCsiSYQ4jH0SSPKwEzSUhacAA==",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^5.15.2",
                 "@fortawesome/fontawesome-svg-core": "^1.2.34",
@@ -17843,9 +17843,9 @@
             "version": "0.1.0"
         },
         "@aics/simularium-viewer": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.8.0.tgz",
-            "integrity": "sha512-u9Wkk7nAwP3bdv9FM9cmx7O15NyEdpU/xMc3/zcP4ck43CuC+zRmiCBoeWwhlQNxrJRsTgbfaMg/dr/SEuN4+Q==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.9.0.tgz",
+            "integrity": "sha512-T9a85XX881mcl0tXWA0MnFZypbPN9PnksLaq40TORxfArMT298GdfjUd0sOsXZCsiSYQ4jH0SSPKwEzSUhacAA==",
             "requires": {
                 "@fortawesome/fontawesome-free": "^5.15.2",
                 "@fortawesome/fontawesome-svg-core": "^1.2.34",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     },
     "dependencies": {
         "@aics/simularium-observables-manager": "^0.1.0",
-        "@aics/simularium-viewer": "^2.8.0",
+        "@aics/simularium-viewer": "^2.9.0",
         "@ant-design/css-animation": "^1.7.3",
         "@ant-design/icons": "^4.0.6",
         "@types/react-plotly.js": "^2.2.4",


### PR DESCRIPTION
Updating simularium-viewer from 2.8.0 to 2.9.0

Changes expected on staging after this update:
1. Many of the playback issues are fixed - https://github.com/allen-cell-animated/simularium-viewer/pull/110
2. Simularium can now read user-set default camera position/orientation info - https://github.com/allen-cell-animated/simularium-viewer/pull/111