### PR TITLE
Fix/Remove Cloudfront instructions from prod deployment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,6 @@ steps are captured in this project's Jenkinsfile and can be executed by setting 
 Automatically builds from `master`
 
 #### Production deployment
-Note: The final two steps require the AWS CLI as well as permissions on AWS to copy to the production S3 bucket and to run a Cloudfront invalidation.
-See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html for details on installing the AWS CLI.
-
 From the Jenkins UI:
 1. Go to this project's `master` branch pipeline page: https://jenkins.corp.alleninstitute.org/job/docker-images/job/docker-agentviz-front-end/job/master/
 2. Select "Build with Parameters" on the left-hand-side navigation menu.
@@ -79,7 +76,6 @@ From the Jenkins UI:
 9. Under the "DEPLOYMENT_TYPE" dropdown, select "production".
 10. In the "GIT_TAG" selectbox, select the tag of the artifact that you just promoted.
 11. Hit "Build".
-13. Run the script "bust-cloudfront-cache.sh" found in this repo's `scripts` directory. That will ensure Cloudfront is serving the newly deployed artifacts.
 
 ### Docker image configuration
 | Env var | Required | Default | Notes |


### PR DESCRIPTION
Doesn't look like it's needed, plus bust-cloudfront-cache.sh doesn't exist on this repo?