### PR TITLE
Fix/Local file playback bugs (update viewer to 2.9.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "@aics/simularium-observables-manager": "^0.1.0",
-                "@aics/simularium-viewer": "^2.9.2",
+                "@aics/simularium-viewer": "^2.9.3",
                 "@ant-design/css-animation": "^1.7.3",
                 "@ant-design/icons": "^4.0.6",
                 "@types/react-plotly.js": "^2.2.4",
@@ -168,9 +168,9 @@
             }
         },
         "node_modules/@aics/simularium-viewer": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.9.2.tgz",
-            "integrity": "sha512-FgGs6Up8vYaH1JFWfjAcWILZ3ybryuP4hPeuzajE7iAQ+X9wXjrBr9oLdsDY3hawoDKT9ENRSan2ibpcPIgiaA==",
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.9.3.tgz",
+            "integrity": "sha512-/k2UHiN/gwFpmtOZbGFJePNPSY5j89LZ5vhO8VdCoq+CtH4TSE6lfjOCW0RTtJZAdJQzTQvWLDnNBshtNKBtjA==",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^5.15.2",
                 "@fortawesome/fontawesome-svg-core": "^1.2.34",
@@ -7083,6 +7083,7 @@
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
             "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
             "dev": true,
+            "hasInstallScript": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -19156,9 +19157,9 @@
             "integrity": "sha512-7G9LM9v3lpEA0xNNPWyceZqRxjiBlP27rMvfosAZcIe5ASVZaotbyjVOWmaFttySgTYtk8W/cKU1AHNHkJpQTA=="
         },
         "@aics/simularium-viewer": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.9.2.tgz",
-            "integrity": "sha512-FgGs6Up8vYaH1JFWfjAcWILZ3ybryuP4hPeuzajE7iAQ+X9wXjrBr9oLdsDY3hawoDKT9ENRSan2ibpcPIgiaA==",
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.9.3.tgz",
+            "integrity": "sha512-/k2UHiN/gwFpmtOZbGFJePNPSY5j89LZ5vhO8VdCoq+CtH4TSE6lfjOCW0RTtJZAdJQzTQvWLDnNBshtNKBtjA==",
             "requires": {
                 "@fortawesome/fontawesome-free": "^5.15.2",
                 "@fortawesome/fontawesome-svg-core": "^1.2.34",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     },
     "dependencies": {
         "@aics/simularium-observables-manager": "^0.1.0",
-        "@aics/simularium-viewer": "^2.9.2",
+        "@aics/simularium-viewer": "^2.9.3",
         "@ant-design/css-animation": "^1.7.3",
         "@ant-design/icons": "^4.0.6",
         "@types/react-plotly.js": "^2.2.4",


### PR DESCRIPTION
Problem
=======
Resolves these bugs:
* [Local playback - sometimes most of the frames in VisData cache disappear](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1428)
* [Local playback doesn't start at updated time after stepping frames](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1426)

Solution
========
Update simularium-viewer to v2.9.3 which contains the fixes for the above.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Pull this branch, then `npm i` and `npm start`
2. Try to reproduce the bugs above