### PR TITLE
remove autodeploy scripts from jenkins file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,24 +79,6 @@ pipeline {
                 sh "./gradlew -i snapshotPublishTarGzAndDockerImage"
             }
         }
-        // TODO: Combine these and paramaterize DEPLOYMENT_ENV such that
-        // on auto-deploy builds DEPLOYMENT_ENV = "staging" and on user trigger it equals the user
-        // chosen param
-        stage ("auto build staging and push: master branch") {
-            when {
-                expression { !IGNORE_AUTHORS.contains(gitAuthor()) }
-                branch "master"
-                equals expected: BUILD_ARTIFACT, actual: params.JOB_TYPE
-            }
-            environment {
-                DEPLOYMENT_ENV = "staging"
-            }
-            steps {
-                sh "${PYTHON} ${VENV_BIN}/manage_version -t gradle -s prepare"
-                sh "./gradlew -i snapshotPublishTarGzAndDockerImage"
-                sh "${PYTHON} ${VENV_BIN}/manage_version -t gradle -s tag"
-            }
-        }
 
         // Defaults to production, but can be switched to staging if user selects
         stage ("build production and push: user trigger") {
@@ -119,29 +101,6 @@ pipeline {
             }
             steps {
                 sh "${PYTHON} ${VENV_BIN}/promote_artifact -t maven -g ${params.GIT_TAG}"
-            }
-        }
-
-        stage("automated deploy") {
-            when {
-                expression { !IGNORE_AUTHORS.contains(gitAuthor()) }
-                branch "master"
-                equals expected: BUILD_ARTIFACT, actual: params.JOB_TYPE
-            }
-
-            steps {
-                script {
-                    DEPLOYMENT_TYPE = STAGING_DEPLOYMENT
-                    CLOUDFRONT_ID = TARGET_CLOUDFRONT[DEPLOYMENT_TYPE]
-                    ARTIFACTORY_REPO = DEPLOYMENT_TARGET_TO_MAVEN_REPO[DEPLOYMENT_TYPE]
-                    S3_BUCKET = DEPLOYMENT_TARGET_TO_S3_BUCKET[DEPLOYMENT_TYPE]
-                    // HACK - switch back to detached commit to get the tag
-                    GIT_TAG = sh(script: 'git checkout - && git describe --tags --exact-match', returnStdout: true).trim()
-                }
-                
-                // Automatically deploy to staging env on changes to master branch
-                sh "${PYTHON} ${VENV_BIN}/deploy_artifact -d --branch=${env.BRANCH_NAME} --deploy-env=${DEPLOYMENT_TYPE} maven-tgz S3 --artifactory-repo=${ARTIFACTORY_REPO} --bucket=${S3_BUCKET} ${GIT_TAG}"
-                invalidateCache(CLOUDFRONT_ID)
             }
         }
 


### PR DESCRIPTION
Problem
=======
We no longer need Jenkins to be auto deploying the master branch on push to staging
[Link to story or ticket](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1452)

Solution
========
Removed code from jenkinsfile

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

