### PR TITLE
Fix/enable Dropbox links in URL param

### DIFF
--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -37,7 +37,9 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
 
     let tagText = "";
 
-    // lastModified is a date in the future if file was loaded via external link in URL param
+    // If the trajectory file was loaded from an external link (trajUrl param), we set
+    // lastModified to a date in the future when we received it (in loadFileViaUrl logic)
+    // to indicate that it's not a real "last modified" date and that it shouldn't be displayed as such
     const shouldShowModifiedDate =
         lastModified && lastModified - Date.now() < 0;
     if (shouldShowModifiedDate) {

--- a/src/components/ViewerTitle/index.tsx
+++ b/src/components/ViewerTitle/index.tsx
@@ -36,7 +36,11 @@ const ViewerTitle: React.FunctionComponent<ViewerTitleProps> = (
     const version = currentTrajectory ? currentTrajectory.version : "";
 
     let tagText = "";
-    if (lastModified) {
+
+    // lastModified is a date in the future if file was loaded via external link in URL param
+    const shouldShowModifiedDate =
+        lastModified && lastModified - Date.now() < 0;
+    if (shouldShowModifiedDate) {
         tagText = `modified: ${moment(lastModified).format(
             "YYYY-MM-DD, h:m A"
         )}`;

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -235,7 +235,10 @@ const loadLocalFile = createLogic({
 const loadFileViaUrl = createLogic({
     process(deps: ReduxLogicDeps, dispatch, done) {
         const { action, getState } = deps;
-        const url = action.payload;
+        const url = action.payload.replace(
+            "dropbox.com",
+            "dl.dropboxusercontent.com"
+        );
         const currentState = getState();
         dispatch(
             setViewerStatus({

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -264,7 +264,7 @@ const loadFileViaUrl = createLogic({
                             data: json,
                             // Temp solution: Set lastModified to a date in the future to tell this apart
                             // from legitimate lastModified values
-                            lastModified: Date.now() + 60000, //TODO: add this to metadata about the file
+                            lastModified: Date.now() + 600000, //TODO: add this to metadata about the file
                         },
                         simulariumController
                     )

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -262,7 +262,9 @@ const loadFileViaUrl = createLogic({
                         {
                             name, //TODO: add this to metadata about the file
                             data: json,
-                            lastModified: Date.now(), //TODO: add this to metadata about the file
+                            // Temp solution: Set lastModified to a date in the future to tell this apart
+                            // from legitimate lastModified values
+                            lastModified: Date.now() + 60000, //TODO: add this to metadata about the file
                         },
                         simulariumController
                     )


### PR DESCRIPTION
Problem
=======
When a user copies and uses the sharing link for a file in their Dropbox as the `trajUrl` param, the trajectory file doesn't load.

Resolves: [modify dropbox links in URL params to enable download](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1453)

Solution
========
Replace `dropbox.com` in the user-supplied URL param with `dl.dropboxusercontent.com`

(I decided to replace `dropbox.com` instead of `www.dropbox` as specified in the Jira issue just in case, because if for some weird reason the user's URL is missing `www.` then replacing `www.dropbox` won't work, whereas replacing `dropbox.com` works in either case)

Sorry for lumping this together, but I also put in a few extra lines of code to hide the misleading "modified" date tag if it's a URL upload. If someone doesn't like it I'll take it out. I just thought not showing a tag at all would be better than supplying false information (currently, the download time is shown as last modified time for URL uploads).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Pull this branch and `npm start`
2. Go here and check that the trajectory loads successfully: http://localhost:9001/viewer?trajUrl=https://www.dropbox.com/s/juhh7os0ae31ju8/example_default.simularium?dl=0
3. This S3 link should still also work: http://localhost:9001/viewer?trajUrl=https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_Run17.simularium

