### PR TITLE
Feature/make error message more informative upon trajUrl fail

### DIFF
--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -285,7 +285,7 @@ const loadFileViaUrl = createLogic({
                 // If there was a CORS error, error.message does not contain a status code
                 if (error.message === "Failed to fetch") {
                     errorDetails +=
-                        " Try uploading your trajectory file from a Dropbox or Amazon S3 link instead.";
+                        "<br/><br/>Try uploading your trajectory file from a Dropbox or Amazon S3 link instead.";
                 }
                 dispatch(
                     setViewerStatus({

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -262,7 +262,9 @@ const loadFileViaUrl = createLogic({
                 }
             })
             .then((json) => {
+                // ex) "mysite.com/myTraj.simularium?dl=0" -> ["mysite.com", "myTraj.simularium?dl=0"]
                 const urlSplit = url.split("/");
+                // ex) ["mysite.com", "myTraj.simularium?dl=0"] -> "myTraj.simularium"
                 const name = urlSplit[urlSplit.length - 1].split("?")[0];
                 dispatch(
                     changeToLocalSimulariumFile(


### PR DESCRIPTION
Problem
=======
When the user attempts to load a trajectory with the trajUrl param and it fails, the error message displayed to the user is not informative enough.

Example of message currently displayed when there is a 404 error due to bad URL:
![image](https://user-images.githubusercontent.com/12690133/121600576-862bf700-c9f9-11eb-9859-6a0bfd4c55ef.png)

Example of message currently displayed when there is a CORS error:
![image](https://user-images.githubusercontent.com/12690133/121600658-a22f9880-c9f9-11eb-8abe-187320229f1f.png)

Resolves: [Show more verbose error messages to user when files don't load](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1455)

Solution
========
If the URL fetch failed but we still got a response of some kind (i.e., not a CORS error), show the HTTP error code and indicate there was a problem fetching:
![image](https://user-images.githubusercontent.com/12690133/121600816-efac0580-c9f9-11eb-9ea3-fe6c5e2041a6.png)

If we didn't even get a response back (likely because of a CORS error), suggest the user use Dropbox or S3 instead:
![image](https://user-images.githubusercontent.com/12690133/121601216-8082e100-c9fa-11eb-8938-a92152f13f2f.png)

While I was at it I also dropped any search params (starting with a `?`) from the file name so that the top nav bar after a Dropbox upload would display `myTraj.simularium` instead of `myTraj.simlarium?dl=0`. It's probably not perfect but I think it's an improvement.

## Type of change
I'm not sure which
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Pull this branch and `npm start`
2. Going to this URL should display a message suggesting that you use Dropbox or S3 instead: http://localhost:9001/viewer?trajUrl=https://drive.google.com/file/d/1HH5KBpH7QAiwqw-qfm0_tfkTO3XC8afR/view?usp=sharing
3. Going to this URL (not a valid Dropbox link) should display a 404 Failed to fetch message: http://localhost:9001/viewer?trajUrl=https://www.dropbox.com/s/zh6qdn4ey58x55
4. Going to this URL should successfully load a trajectory and show the file name correctly: http://localhost:9001/viewer?trajUrl=https://www.dropbox.com/s/zh6qdn4ey58x55f/nanoparticle_wrapping.simularium?dl=0