### PR TITLE
Feature/set time with text input

### DIFF
--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button, Slider, Tooltip } from "antd";
+import { Button, Slider, Tooltip, InputNumber } from "antd";
 import classNames from "classnames";
 
 import { TOOLTIP_COLOR } from "../../constants/index";
@@ -43,6 +43,7 @@ const PlayBackControls = ({
         timeToResumeAfterScrubbing,
         setTimeToResumeAfterScrubbing,
     ] = useState(-1);
+    const [timeInput, setTimeInput] = useState(firstFrameTime);
 
     // - Gets called once when the user clicks on the slider to skip to a specific time
     // - Gets called multiple times when user is scrubbing (every time the play head
@@ -69,6 +70,18 @@ const PlayBackControls = ({
             playHandler(timeToResumeAfterScrubbing);
             setTimeToResumeAfterScrubbing(-1);
         }
+    };
+
+    const handleTimeInputChange = (
+        timeInput: number | string | undefined
+    ): void => {
+        if (timeInput !== undefined) {
+            setTimeInput(timeInput as number);
+        }
+    };
+
+    const handleTimeInputEnter = (): void => {
+        onTimeChange(timeInput as number);
     };
 
     const btnClassNames = classNames([styles.item, styles.btn]);
@@ -159,13 +172,21 @@ const PlayBackControls = ({
                 disabled={loading || isEmpty}
             />
             <div className={styles.time}>
-                <p>
-                    {displayTimes.roundedTime}{" "}
-                    <span className={styles.lastFrameTime}>
-                        / {displayTimes.roundedLastFrameTime}{" "}
-                        {displayTimes.unitLabel}
-                    </span>
-                </p>
+                <InputNumber
+                    size="small"
+                    step={timeStep}
+                    min={firstFrameTime}
+                    max={lastFrameTime}
+                    value={displayTimes.roundedTime}
+                    onChange={handleTimeInputChange}
+                    onPressEnter={handleTimeInputEnter}
+                    disabled={loading || isEmpty || isPlaying}
+                    // formatter={}
+                />
+                <span className={styles.lastFrameTime}>
+                    / {displayTimes.roundedLastFrameTime}{" "}
+                    {displayTimes.unitLabel}
+                </span>
             </div>
         </div>
     );

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -5,6 +5,7 @@ import classNames from "classnames";
 import { TOOLTIP_COLOR } from "../../constants/index";
 import Icons from "../Icons";
 import { DisplayTimes } from "../../containers/ViewerPanel/types";
+import { TimeUnits } from "../../state/metadata/types";
 
 const styles = require("./style.css");
 interface PlayBackProps {
@@ -20,6 +21,7 @@ interface PlayBackProps {
     loading: boolean;
     timeStep: number;
     displayTimes: DisplayTimes;
+    timeUnits: TimeUnits;
     isEmpty: boolean;
 }
 
@@ -36,6 +38,7 @@ const PlayBackControls = ({
     loading,
     timeStep,
     displayTimes,
+    timeUnits,
     isEmpty,
 }: PlayBackProps) => {
     // Where to resume playing if simulation was playing before scrubbing
@@ -73,15 +76,15 @@ const PlayBackControls = ({
     };
 
     const handleTimeInputChange = (
-        timeInput: number | string | undefined
+        userInput: number | string | undefined
     ): void => {
-        if (timeInput !== undefined) {
-            setTimeInput(timeInput as number);
+        if (userInput !== undefined) {
+            setTimeInput(userInput as number);
         }
     };
 
     const handleTimeInputEnter = (): void => {
-        onTimeChange(timeInput as number);
+        onTimeChange(timeInput / timeUnits.magnitude);
     };
 
     const getTimeInputWidth = (): string => {
@@ -180,7 +183,7 @@ const PlayBackControls = ({
             />
             <div className={styles.time}>
                 <InputNumber
-                    // Necessary to re-render this component and override user input
+                    // key is necessary to re-render this component and override user input
                     key={displayTimes.roundedTime}
                     size="small"
                     value={displayTimes.roundedTime}
@@ -191,7 +194,7 @@ const PlayBackControls = ({
                 />
                 <span className={styles.lastFrameTime}>
                     / {displayTimes.roundedLastFrameTime}{" "}
-                    {displayTimes.unitLabel}
+                    {timeUnits ? timeUnits.name : "s"}
                 </span>
             </div>
         </div>

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -90,7 +90,9 @@ const PlayBackControls = ({
             // by timeUnits.magnitude in the getDisplayTimes selector, so we have to undo the
             // multiplication before requesting the time. timeUnits.magnitude is 1 for a vast
             // majority of the time so it shouldn't make a difference most times.
-            onTimeChange(timeInput / timeUnits.magnitude);
+            if (typeof timeInput === "number") {
+                onTimeChange(timeInput / timeUnits.magnitude);
+            }
         }
     };
 

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -176,14 +176,10 @@ const PlayBackControls = ({
                     // Necessary to re-render this component and override user input
                     key={displayTimes.roundedTime}
                     size="small"
-                    step={timeStep}
-                    min={firstFrameTime}
-                    max={lastFrameTime}
                     value={displayTimes.roundedTime}
                     onChange={handleTimeInputChange}
                     onPressEnter={handleTimeInputEnter}
                     disabled={loading || isEmpty || isPlaying}
-                    // formatter={}
                 />
                 <span className={styles.lastFrameTime}>
                     / {displayTimes.roundedLastFrameTime}{" "}

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -84,9 +84,12 @@ const PlayBackControls = ({
         onTimeChange(timeInput as number);
     };
 
-    const inputNumberWidth =
-        Math.min(displayTimes.roundedLastFrameTime.toString().length + 5, 7) +
-        "ch";
+    const getTimeInputWidth = (): string => {
+        const longTimeValue =
+            displayTimes.roundedLastFrameTime + displayTimes.roundedTimeStep;
+        const longTimeValueLength = longTimeValue.toString().length;
+        return longTimeValueLength + 1 + "ch";
+    };
 
     const btnClassNames = classNames([styles.item, styles.btn]);
 
@@ -184,7 +187,7 @@ const PlayBackControls = ({
                     onChange={handleTimeInputChange}
                     onPressEnter={handleTimeInputEnter}
                     disabled={loading || isEmpty || isPlaying}
-                    style={{ width: inputNumberWidth }}
+                    style={{ width: getTimeInputWidth() }}
                 />
                 <span className={styles.lastFrameTime}>
                     / {displayTimes.roundedLastFrameTime}{" "}

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -75,6 +75,7 @@ const PlayBackControls = ({
         }
     };
 
+    // Called after every keystroke
     const handleTimeInputChange = (
         userInput: number | string | undefined
     ): void => {
@@ -83,15 +84,24 @@ const PlayBackControls = ({
         }
     };
 
-    const handleTimeInputEnter = (): void => {
+    const handleTimeInputPressEnter = (): void => {
+        // User input will be aligned with the displayed time values, which were multiplied
+        // by timeUnits.magnitude in the getDisplayTimes selector, so we have to undo the
+        // multiplication before requesting the time. timeUnits.magnitude is 1 for a vast
+        // majority of the time so it shouldn't make a difference most times.
         onTimeChange(timeInput / timeUnits.magnitude);
     };
 
+    // Determine the width of the input box
     const getTimeInputWidth = (): string => {
-        const longTimeValue =
+        // If lastFrameTime is 15 and step size is 0.25 then 15.25 is probably going to have
+        // the max number of characters for this trajectory
+        const refTimeValue =
             displayTimes.roundedLastFrameTime + displayTimes.roundedTimeStep;
-        const longTimeValueLength = longTimeValue.toString().length;
-        return longTimeValueLength + 1 + "ch";
+        const maxNumChars = refTimeValue.toString().length;
+        // If maxNumChars is 5 then the input box width will be 6 character widths long
+        // (+ 1 is arbitrary padding)
+        return maxNumChars + 1 + "ch";
     };
 
     const btnClassNames = classNames([styles.item, styles.btn]);
@@ -188,7 +198,7 @@ const PlayBackControls = ({
                     size="small"
                     value={displayTimes.roundedTime}
                     onChange={handleTimeInputChange}
-                    onPressEnter={handleTimeInputEnter}
+                    onPressEnter={handleTimeInputPressEnter}
                     disabled={loading || isEmpty || isPlaying}
                     style={{ width: getTimeInputWidth() }}
                 />

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -84,6 +84,10 @@ const PlayBackControls = ({
         onTimeChange(timeInput as number);
     };
 
+    const inputNumberWidth =
+        Math.min(displayTimes.roundedLastFrameTime.toString().length + 5, 7) +
+        "ch";
+
     const btnClassNames = classNames([styles.item, styles.btn]);
 
     return (
@@ -180,6 +184,7 @@ const PlayBackControls = ({
                     onChange={handleTimeInputChange}
                     onPressEnter={handleTimeInputEnter}
                     disabled={loading || isEmpty || isPlaying}
+                    style={{ width: inputNumberWidth }}
                 />
                 <span className={styles.lastFrameTime}>
                     / {displayTimes.roundedLastFrameTime}{" "}

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { KeyboardEvent, useState } from "react";
 import { Button, Slider, Tooltip, InputNumber } from "antd";
 import classNames from "classnames";
 
@@ -84,12 +84,14 @@ const PlayBackControls = ({
         }
     };
 
-    const handleTimeInputPressEnter = (): void => {
-        // User input will be aligned with the displayed time values, which were multiplied
-        // by timeUnits.magnitude in the getDisplayTimes selector, so we have to undo the
-        // multiplication before requesting the time. timeUnits.magnitude is 1 for a vast
-        // majority of the time so it shouldn't make a difference most times.
-        onTimeChange(timeInput / timeUnits.magnitude);
+    const handleTimeInputKeyDown = (event: KeyboardEvent): void => {
+        if (event.key === "Enter" || event.key === "Tab") {
+            // User input will be aligned with the displayed time values, which were multiplied
+            // by timeUnits.magnitude in the getDisplayTimes selector, so we have to undo the
+            // multiplication before requesting the time. timeUnits.magnitude is 1 for a vast
+            // majority of the time so it shouldn't make a difference most times.
+            onTimeChange(timeInput / timeUnits.magnitude);
+        }
     };
 
     // Determine the width of the input box
@@ -198,7 +200,7 @@ const PlayBackControls = ({
                     size="small"
                     value={displayTimes.roundedTime}
                     onChange={handleTimeInputChange}
-                    onPressEnter={handleTimeInputPressEnter}
+                    onKeyDown={handleTimeInputKeyDown}
                     disabled={loading || isEmpty || isPlaying}
                     style={{ width: getTimeInputWidth() }}
                 />

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -173,6 +173,8 @@ const PlayBackControls = ({
             />
             <div className={styles.time}>
                 <InputNumber
+                    // Necessary to re-render this component and override user input
+                    key={displayTimes.roundedTime}
                     size="small"
                     step={timeStep}
                     min={firstFrameTime}

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -94,6 +94,10 @@ const PlayBackControls = ({
                 onTimeChange(timeInput / timeUnits.magnitude);
             }
         }
+        if (event.key === "Escape") {
+            const inputNumberComponent = event.target as HTMLElement;
+            inputNumberComponent.blur();
+        }
     };
 
     // Determine the width of the input box

--- a/src/components/PlaybackControls/style.css
+++ b/src/components/PlaybackControls/style.css
@@ -14,7 +14,8 @@
 
 .container :global(.ant-input-number input) {
     color: var(--dark-theme-btn-color);
-    text-align: right;
+    text-align: center;
+    padding: 0 3px;
 }
 
 /* Hide the up/down buttons in the time input box */
@@ -72,7 +73,7 @@
     font-weight: 300;
     background-color: var(--dark-theme-btn-bg);
     color: var(--dark-theme-btn-color);
-    height: 24px;
+    height: 26px;
     min-width: 100px;
     padding: 1px 7px 4px 7px;
     border-radius: 3px;

--- a/src/components/PlaybackControls/style.css
+++ b/src/components/PlaybackControls/style.css
@@ -8,6 +8,15 @@
     margin-bottom: 20px;
 }
 
+.container :global(.ant-input-number) {
+    background-color: transparent;
+}
+
+.container :global(.ant-input-number input) {
+    color: var(--dark-theme-btn-color);
+    text-align: right;
+}
+
 /* Hide the up/down buttons in the time input box */
 .container :global(.ant-input-number-handler-wrap) {
     display: none;

--- a/src/components/PlaybackControls/style.css
+++ b/src/components/PlaybackControls/style.css
@@ -8,6 +8,11 @@
     margin-bottom: 20px;
 }
 
+/* Hide the up/down buttons in the time input box */
+.container :global(.ant-input-number-handler-wrap) {
+    display: none;
+}
+
 .item {
     margin: auto 2px;
 }

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -430,7 +430,7 @@ function mapStateToProps(state: State) {
             state
         ),
         numFrames: metadataStateBranch.selectors.getNumFrames(state),
-        timeStep: metadataStateBranch.selectors.getTimeStepSize(state),
+        timeStep: metadataStateBranch.selectors.getTimeStep(state),
         displayTimes: getDisplayTimes(state),
         timeUnits: metadataStateBranch.selectors.getTimeUnits(state),
         selectionStateInfoForViewer: getSelectionStateInfoForViewer(state),

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -30,6 +30,7 @@ import {
     LocalSimFile,
     SetViewerStatusAction,
     ViewerError,
+    TimeUnits,
 } from "../../state/metadata/types";
 import { VIEWER_ERROR } from "../../state/metadata/constants";
 import { batchActions } from "../../state/util";
@@ -57,6 +58,7 @@ interface ViewerPanelProps {
     firstFrameTime: number;
     lastFrameTime: number;
     displayTimes: DisplayTimes;
+    timeUnits: TimeUnits;
     isPlaying: boolean;
     fileIsDraggedOverViewer: boolean;
     viewerStatus: string;
@@ -354,6 +356,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             selectionStateInfoForViewer,
             setViewerStatus,
             timeStep,
+            timeUnits,
             displayTimes,
             isBuffering,
             isPlaying,
@@ -392,6 +395,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
                     time={time}
                     timeStep={timeStep}
                     displayTimes={displayTimes}
+                    timeUnits={timeUnits}
                     onTimeChange={this.skipToTime}
                     pauseHandler={this.pause}
                     prevHandler={this.playBackOne}
@@ -428,6 +432,7 @@ function mapStateToProps(state: State) {
         numFrames: metadataStateBranch.selectors.getNumFrames(state),
         timeStep: metadataStateBranch.selectors.getTimeStepSize(state),
         displayTimes: getDisplayTimes(state),
+        timeUnits: metadataStateBranch.selectors.getTimeUnits(state),
         selectionStateInfoForViewer: getSelectionStateInfoForViewer(state),
         viewerStatus: metadataStateBranch.selectors.getViewerStatus(state),
         viewerError: metadataStateBranch.selectors.getViewerError(state),

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -248,7 +248,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
 
         receiveMetadata({
             numFrames: data.totalSteps,
-            timeStepSize: data.timeStepSize * data.timeUnits.magnitude,
+            timeStep: data.timeStepSize,
             timeUnits: data.timeUnits,
         });
 

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -3,7 +3,7 @@ import { createSelector } from "reselect";
 import {
     getLastFrameTimeOfCachedSimulation,
     getTimeUnits,
-    getTimeStepSize,
+    getTimeStep,
 } from "../../state/metadata/selectors";
 import {
     getAgentsToHide,
@@ -56,10 +56,10 @@ export const getDisplayTimes = createSelector(
     [
         getCurrentTime,
         getTimeUnits,
-        getTimeStepSize,
+        getTimeStep,
         getLastFrameTimeOfCachedSimulation,
     ],
-    (time, timeUnits, timeStepSize, lastFrameTime): DisplayTimes => {
+    (time, timeUnits, timeStep, lastFrameTime): DisplayTimes => {
         const roundNumber = (num: number) =>
             parseFloat(Number(num).toPrecision(3));
         let roundedTime = 0;
@@ -71,7 +71,7 @@ export const getDisplayTimes = createSelector(
             roundedLastFrameTime = roundNumber(
                 lastFrameTime * timeUnits.magnitude
             );
-            roundedTimeStep = roundNumber(timeStepSize);
+            roundedTimeStep = roundNumber(timeStep * timeUnits.magnitude);
         }
 
         return {

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -65,7 +65,6 @@ export const getDisplayTimes = createSelector(
         let roundedTime = 0;
         let roundedLastFrameTime = 0;
         let roundedTimeStep = 0;
-        let unitLabel = "s";
 
         if (timeUnits) {
             roundedTime = time ? roundNumber(time * timeUnits.magnitude) : 0;
@@ -73,14 +72,12 @@ export const getDisplayTimes = createSelector(
                 lastFrameTime * timeUnits.magnitude
             );
             roundedTimeStep = roundNumber(timeStepSize);
-            unitLabel = timeUnits.name;
         }
 
         return {
             roundedTime: roundedTime,
             roundedLastFrameTime: roundedLastFrameTime,
             roundedTimeStep: roundedTimeStep,
-            unitLabel: unitLabel,
         };
     }
 );

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -3,6 +3,7 @@ import { createSelector } from "reselect";
 import {
     getLastFrameTimeOfCachedSimulation,
     getTimeUnits,
+    getTimeStepSize,
 } from "../../state/metadata/selectors";
 import {
     getAgentsToHide,
@@ -13,6 +14,7 @@ import {
     AgentColorMap,
     VisibilitySelectionMap,
 } from "../../state/selection/types";
+import { DisplayTimes } from "./types";
 
 export const getSelectionStateInfoForViewer = createSelector(
     [getHightLightedAgents, getAgentsToHide],
@@ -51,12 +53,18 @@ export const convertUIDataToColorMap = (
 };
 
 export const getDisplayTimes = createSelector(
-    [getCurrentTime, getTimeUnits, getLastFrameTimeOfCachedSimulation],
-    (time, timeUnits, lastFrameTime) => {
+    [
+        getCurrentTime,
+        getTimeUnits,
+        getTimeStepSize,
+        getLastFrameTimeOfCachedSimulation,
+    ],
+    (time, timeUnits, timeStepSize, lastFrameTime): DisplayTimes => {
         const roundNumber = (num: number) =>
             parseFloat(Number(num).toPrecision(3));
         let roundedTime = 0;
         let roundedLastFrameTime = 0;
+        let roundedTimeStep = 0;
         let unitLabel = "s";
 
         if (timeUnits) {
@@ -64,12 +72,14 @@ export const getDisplayTimes = createSelector(
             roundedLastFrameTime = roundNumber(
                 lastFrameTime * timeUnits.magnitude
             );
+            roundedTimeStep = roundNumber(timeStepSize);
             unitLabel = timeUnits.name;
         }
 
         return {
             roundedTime: roundedTime,
             roundedLastFrameTime: roundedLastFrameTime,
+            roundedTimeStep: roundedTimeStep,
             unitLabel: unitLabel,
         };
     }

--- a/src/containers/ViewerPanel/test/selectors.test.ts
+++ b/src/containers/ViewerPanel/test/selectors.test.ts
@@ -46,7 +46,7 @@ describe("ViewerPanel selectors", () => {
             });
         });
 
-        it("shows correct values and units when timeUnits.magnitude is not 1", () => {
+        it("shows correct values when timeUnits.magnitude is not 1", () => {
             const mockState: State = {
                 ...initialState,
                 selection: {

--- a/src/containers/ViewerPanel/test/selectors.test.ts
+++ b/src/containers/ViewerPanel/test/selectors.test.ts
@@ -15,11 +15,11 @@ describe("ViewerPanel selectors", () => {
             expect(displayTimes).to.deep.equal({
                 roundedTime: 0,
                 roundedLastFrameTime: 0,
-                unitLabel: "s",
+                roundedTimeStep: 0,
             });
         });
 
-        it("rounds current time and lastFrameTime", () => {
+        it("rounds current time, timeStep, and lastFrameTime", () => {
             const mockState: State = {
                 ...initialState,
                 selection: {
@@ -32,6 +32,7 @@ describe("ViewerPanel selectors", () => {
                         magnitude: 1,
                         name: "s",
                     },
+                    timeStep: 0.100000000023,
                     lastFrameTime: 15.0001,
                 },
             };
@@ -41,33 +42,7 @@ describe("ViewerPanel selectors", () => {
             expect(displayTimes).to.deep.equal({
                 roundedTime: 3,
                 roundedLastFrameTime: 15,
-                unitLabel: "s",
-            });
-        });
-
-        it("returns user-set non-second time unit", () => {
-            const mockState: State = {
-                ...initialState,
-                selection: {
-                    ...initialState.selection,
-                    time: 3,
-                },
-                metadata: {
-                    ...initialState.metadata,
-                    timeUnits: {
-                        magnitude: 1,
-                        name: "ns",
-                    },
-                    lastFrameTime: 15,
-                },
-            };
-
-            const displayTimes = getDisplayTimes(mockState);
-
-            expect(displayTimes).to.deep.equal({
-                roundedTime: 3,
-                roundedLastFrameTime: 15,
-                unitLabel: "ns",
+                roundedTimeStep: 0.1,
             });
         });
 
@@ -84,6 +59,7 @@ describe("ViewerPanel selectors", () => {
                         magnitude: 2,
                         name: "ns",
                     },
+                    timeStep: 0.100000000023,
                     lastFrameTime: 15.0001,
                 },
             };
@@ -93,7 +69,7 @@ describe("ViewerPanel selectors", () => {
             expect(displayTimes).to.deep.equal({
                 roundedTime: 6,
                 roundedLastFrameTime: 30,
-                unitLabel: "ns",
+                roundedTimeStep: 0.2,
             });
         });
     });

--- a/src/containers/ViewerPanel/types.ts
+++ b/src/containers/ViewerPanel/types.ts
@@ -2,5 +2,4 @@ export interface DisplayTimes {
     roundedTime: number;
     roundedLastFrameTime: number;
     roundedTimeStep: number;
-    unitLabel: string;
 }

--- a/src/containers/ViewerPanel/types.ts
+++ b/src/containers/ViewerPanel/types.ts
@@ -1,5 +1,6 @@
 export interface DisplayTimes {
     roundedTime: number;
     roundedLastFrameTime: number;
+    roundedTimeStep: number;
     unitLabel: string;
 }

--- a/src/state/metadata/selectors.ts
+++ b/src/state/metadata/selectors.ts
@@ -19,7 +19,7 @@ export const getFirstFrameTimeOfCachedSimulation = (state: State) =>
 export const getLastFrameTimeOfCachedSimulation = (state: State) =>
     state.metadata.lastFrameTime;
 export const getNumFrames = (state: State) => state.metadata.numFrames;
-export const getTimeStepSize = (state: State) => state.metadata.timeStepSize;
+export const getTimeStep = (state: State) => state.metadata.timeStep;
 export const getTimeUnits = (state: State) => state.metadata.timeUnits;
 export const getAgentIds = (state: State) => state.metadata.agentIds;
 export const getSimulariumFile = (state: State) =>


### PR DESCRIPTION
Problem
=======
Users can't specify a specific time to skip to.

Resolves: [set time with text input](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1293)
Also resolves: [Slider length changes when displayed times have many digits](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1421)

Solution
========
* Turned the current time display into an interactive number input. 
    * Enter or Tab to trigger time change
    * Esc to cancel entry
* The appropriate width of the input box for a given trajectory is determined and set in the beginning, which also solves the problem of the time display width and slider length changing throughout playback.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This PR requires updated tests

Steps to Verify:
----------------
1. Pull this branch and `npm start`
2. Load any trajectory and try to specify the time you want to skip to. It should work without breaking any existing functionality 😛 
3. Check other expected behaviors (these were not explicitly specified in the issue so I didn't _try_ to make most of these behaviors happen, but this is how things behave and they seems desirable/acceptable for now):
    * Input box is disabled when the trajectory is loading or playing or if there is no trajectory loaded
    * If you input anything invalid (non-number, a time value outside of the min-max times, etc.) and hit enter, nothing happens
    * If you input a time value that matches a frame time exactly (for example, 2.3 when step size is 0.1) then the viewer should skip to that exact time
    * If you input a time value that's inside the min-max time range but doesn't match a frame time exactly (for example, 2.35 when step size is 0.1) then the viewer will skip to a frame that's closest to that time

Screenshots (optional):
-----------------------
User is interacting:
![image](https://user-images.githubusercontent.com/12690133/122451549-21bee980-cf5d-11eb-98e7-df6adfe793fc.png)
User is not interacting (no change from before):
![image](https://user-images.githubusercontent.com/12690133/122451619-37ccaa00-cf5d-11eb-9155-578df13ba18e.png)

Keyfiles (delete if not relevant):
-----------------------
1. src/components/PlaybackControls/index.tsx - See code comments
2. src/containers/ViewerPanel/selectors.ts - I modified `getDisplayTimes` to supply `roundedTimeStep` instead of `unitLabel`. 
    * I'm importing `timeUnits` (containing unit label and magnitude (multiplier)) directly into the `ViewerPanel` container now, so don't need to get the unit label here.
    * On the other hand `rounedTimeStep` is needed in `PlaybackControls` to determine the width of the time input box.
3. src/state/metadata/selectors.ts - New unit tests revealed that the `getTimeStepSize` selector was erroneously getting `metadata.timeStepSize` instead of the correct `metadata.timeStep` which is used elsewhere in the repo like in `metadata.initialState`. So I fixed it.
4. src/containers/ViewerPanel/index.tsx - I realized that we shouldn't multiply the time step by `timeUnits.magnitude` upon receipt, because the multiplication should only happen for display purposes!! So I removed that. It's been inconsequential so far because [almost?] all the magnitudes have been 1. 