### PR TITLE
Feature/update supported engines on tutorial page

### DIFF
--- a/src/components/TutorialPage/index.tsx
+++ b/src/components/TutorialPage/index.tsx
@@ -5,7 +5,7 @@ import { Layout, Typography } from "antd";
 import dragDropImage from "../../assets/drag-drop.gif";
 import { VIEWER_PATHNAME } from "../../routes";
 import VisualGlossary from "../VisualGlossary";
-import { CYTOSIM_URL, PHYSICELL_URL, READDY_URL } from "../../constants";
+import { SUPPORTED_ENGINES } from "../../constants";
 import Footer from "../Footer";
 
 const { Content } = Layout;
@@ -125,39 +125,24 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                                 <li>
                                     We support the following simulators:
                                     <ul>
-                                        <li>
-                                            ReaDDy (
-                                            <a
-                                                href={READDY_URL}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                {READDY_URL}
-                                            </a>
-                                            )
-                                        </li>
-                                        <li>
-                                            PhysiCell (
-                                            <a
-                                                href={PHYSICELL_URL}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                {PHYSICELL_URL}
-                                            </a>
-                                            )
-                                        </li>
-                                        <li>
-                                            CytoSim (
-                                            <a
-                                                href={CYTOSIM_URL}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                {CYTOSIM_URL}
-                                            </a>
-                                            )
-                                        </li>
+                                        {SUPPORTED_ENGINES.map(
+                                            (engine: string[]) => {
+                                                const [name, url] = engine;
+                                                return (
+                                                    <li key={name}>
+                                                        {name} (
+                                                        <a
+                                                            href={url}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                        >
+                                                            {url}
+                                                        </a>
+                                                        )
+                                                    </li>
+                                                );
+                                            }
+                                        )}
                                     </ul>
                                 </li>
                                 <li>
@@ -165,33 +150,23 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                                     to generate your data, choose the notebook
                                     for that simulator:
                                     <ul>
-                                        <li>
-                                            <a
-                                                href="https://github.com/allen-cell-animated/simulariumio/blob/master/examples/Tutorial_readdy.ipynb"
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                ReaDDy
-                                            </a>
-                                        </li>
-                                        <li>
-                                            <a
-                                                href="https://github.com/allen-cell-animated/simulariumio/blob/master/examples/Tutorial_physicell.ipynb"
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                PhysiCell
-                                            </a>
-                                        </li>
-                                        <li>
-                                            <a
-                                                href="https://github.com/allen-cell-animated/simulariumio/blob/master/examples/Tutorial_cytosim.ipynb"
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                CytoSim
-                                            </a>
-                                        </li>
+                                        {SUPPORTED_ENGINES.map(
+                                            (engine: string[]) => {
+                                                const name = engine[0];
+                                                const url = `https://github.com/allen-cell-animated/simulariumio/blob/master/examples/Tutorial_${name.toLowerCase()}.ipynb`;
+                                                return (
+                                                    <li key={name}>
+                                                        <a
+                                                            href={url}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                        >
+                                                            {name}
+                                                        </a>
+                                                    </li>
+                                                );
+                                            }
+                                        )}
                                     </ul>
                                 </li>
                                 <li>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -25,3 +25,17 @@ export const CONTACT_FORM_URL = "https://forms.gle/mwoJjaj3PcbTVStU7";
 export const CYTOSIM_URL = "https://gitlab.com/f.nedelec/cytosim";
 export const PHYSICELL_URL = "http://physicell.org/";
 export const READDY_URL = "https://readdy.github.io/";
+export const MCELL_URL = "https://mcell.org/";
+export const SMOLDYN_URL = "http://www.smoldyn.org/";
+export const SPRINGSALAD_URL = "https://vcell.org/ssalad";
+export const MEDYAN_URL = "http://medyan.org/";
+
+export const SUPPORTED_ENGINES = [
+    ["ReaDDy", READDY_URL],
+    ["PhysiCell", PHYSICELL_URL],
+    ["CytoSim", CYTOSIM_URL],
+    ["MCell", MCELL_URL],
+    ["Smoldyn", SMOLDYN_URL],
+    ["SpringSaLaD", SPRINGSALAD_URL],
+    ["MEDYAN", MEDYAN_URL],
+];


### PR DESCRIPTION
Problem
=======
We need to add to the list of supported simulation engines on the tutorial page.

Closes #146 

Solution
========
I added the new engines and replaced some redundant HTML with a `map` function.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Pull this branch and `npm start`
2. Go to Help -> Quick Start and verify new list items look right and that the links work.

Screenshots (optional):
-----------------------
![image](https://user-images.githubusercontent.com/12690133/122852748-fa9e4a00-d2c5-11eb-8482-18bd50df7e2d.png)
