### PR TITLE
Fix/in modified state still click buttons

### DIFF
--- a/src/components/CameraControls/index.tsx
+++ b/src/components/CameraControls/index.tsx
@@ -39,11 +39,12 @@ const CameraControls = ({
 
     const isModifierKey = (key: string) =>
         CAMERA_MODE_MODIFIER_KEYS.includes(key);
-    const modifierKeyIsPressed = (isPressed) => {
+
+    const getModifierKeyPressed = () => {
+        const isPressed = useIsHotkeyPressed();
+
         return CAMERA_MODE_MODIFIER_KEYS.reduce((acc, key) => {
-            console.log("key", key);
             if (isPressed(key)) {
-                console.log("is pressed", key);
                 acc = key;
             }
             return acc;
@@ -66,10 +67,9 @@ const CameraControls = ({
     useHotkeys(
         "*",
         () => {
-            const isPressed = useIsHotkeyPressed();
-            const modifierKeyPressed = modifierKeyIsPressed(isPressed);
-            if (!!modifierKeyPressed) {
-                return setKeyPressed(modifierKeyPressed);
+            const currentModifierKeyPressed = getModifierKeyPressed();
+            if (!!currentModifierKeyPressed) {
+                return setKeyPressed(currentModifierKeyPressed);
             }
             return setKeyPressed("");
         },

--- a/src/components/CameraControls/index.tsx
+++ b/src/components/CameraControls/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import { Button, Tooltip } from "antd";
 import classNames from "classnames";
-import { useHotkeys } from "react-hotkeys-hook";
+import { useHotkeys, useIsHotkeyPressed } from "react-hotkeys-hook";
 
 import { TOOLTIP_COLOR } from "../../constants/index";
 import Icons from "../Icons";
@@ -39,6 +39,17 @@ const CameraControls = ({
 
     const isModifierKey = (key: string) =>
         CAMERA_MODE_MODIFIER_KEYS.includes(key);
+    const modifierKeyIsPressed = (isPressed) => {
+        return CAMERA_MODE_MODIFIER_KEYS.reduce((acc, key) => {
+            console.log("key", key);
+            if (isPressed(key)) {
+                console.log("is pressed", key);
+                acc = key;
+            }
+            return acc;
+        }, "");
+    };
+
     useHotkeys(
         "*",
         (event) => {
@@ -55,6 +66,11 @@ const CameraControls = ({
     useHotkeys(
         "*",
         () => {
+            const isPressed = useIsHotkeyPressed();
+            const modifierKeyPressed = modifierKeyIsPressed(isPressed);
+            if (!!modifierKeyPressed) {
+                return setKeyPressed(modifierKeyPressed);
+            }
             return setKeyPressed("");
         },
         { keyup: true }


### PR DESCRIPTION
Problem
=======
If you held down a modifier key and then clicked another camera control key, like the up button, it would break the state indicator (ie you'd still be in pan state, but the toggle button would show rotate state) 
resolves #150 

Solution
========
Check to see if a modifier is being held in key up listener 
with @pairperson1

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. npm start
1. hold down shift
1. click down or up button
1. let go of shift
1. rotate toggle button should switch only once you release the shift button

