### PR TITLE
Feature/toggle tooltips pan/rotate

### DIFF
--- a/src/components/CameraControls/index.tsx
+++ b/src/components/CameraControls/index.tsx
@@ -39,6 +39,7 @@ const CameraControls = ({
 
     const isModifierKey = (key: string) =>
         CAMERA_MODE_MODIFIER_KEYS.includes(key);
+
     useHotkeys(
         "*",
         (event) => {
@@ -108,7 +109,11 @@ const CameraControls = ({
                 <div className={styles.radioGroup}>
                     <Tooltip
                         placement="left"
-                        title="Rotate (SHIFT or CMD)"
+                        title={
+                            mode === ROTATE
+                                ? "Rotate"
+                                : "Rotate (Hold CMD and drag)"
+                        }
                         color={TOOLTIP_COLOR}
                     >
                         {/* Should be radio buttons, but using radio buttons 
@@ -131,7 +136,7 @@ const CameraControls = ({
                     </Tooltip>
                     <Tooltip
                         placement="left"
-                        title="Pan (SHIFT or CMD)"
+                        title={mode === PAN ? "Pan" : "Pan (Hold CMD and drag)"}
                         color={TOOLTIP_COLOR}
                     >
                         <Button

--- a/src/components/CameraControls/index.tsx
+++ b/src/components/CameraControls/index.tsx
@@ -110,9 +110,7 @@ const CameraControls = ({
                     <Tooltip
                         placement="left"
                         title={
-                            mode === ROTATE
-                                ? "Rotate"
-                                : "Rotate (Hold CMD and drag)"
+                            mode === ROTATE ? "Rotate" : "Rotate (hold SHIFT)"
                         }
                         color={TOOLTIP_COLOR}
                     >
@@ -136,7 +134,7 @@ const CameraControls = ({
                     </Tooltip>
                     <Tooltip
                         placement="left"
-                        title={mode === PAN ? "Pan" : "Pan (Hold CMD and drag)"}
+                        title={mode === PAN ? "Pan" : "Pan (hold SHIFT)"}
                         color={TOOLTIP_COLOR}
                     >
                         <Button


### PR DESCRIPTION
Problem
=======
Tool tips are a bit confusing currently since the same modifier toggles pan/rotate 

resolves #149 

Solution
========
Changed the tool tip to reflect the state. 

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. npm start
2. hover over pan button to see tool tip
1. click pan button
1. hover over rotate button
1. tool tips should change based on selected button

Screenshots (optional):
-----------------------
<img width="239" alt="Screen Shot 2021-06-25 at 11 46 12 AM" src="https://user-images.githubusercontent.com/5170636/123477219-9542a580-d5b2-11eb-9260-8192590196cb.png">
<img width="311" alt="Screen Shot 2021-06-25 at 11 46 22 AM" src="https://user-images.githubusercontent.com/5170636/123477224-95db3c00-d5b2-11eb-9e3d-3fe42e61c63c.png">

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
