### PR TITLE
Feature/change reset hotkey

### DIFF
--- a/src/components/CameraControls/index.tsx
+++ b/src/components/CameraControls/index.tsx
@@ -13,7 +13,7 @@ const ROTATE = "rotate";
 const CAMERA_MODE_MODIFIER_KEYS = ["Meta", "Shift"];
 const ZOOM_IN_HK = "ArrowUp";
 const ZOOM_OUT_HK = "ArrowDown";
-const RESET_HK = "r";
+const RESET_HK = "h";
 const FOCUS_HK = "f";
 const HOT_KEYS = [ZOOM_IN_HK, ZOOM_OUT_HK, RESET_HK, FOCUS_HK];
 
@@ -203,7 +203,7 @@ const CameraControls = ({
             </div>
             <Tooltip
                 placement="left"
-                title="Reset camera (R)"
+                title="Home view (H)"
                 color={TOOLTIP_COLOR}
             >
                 <Button


### PR DESCRIPTION
Problem
=======
"R" is a button we might want to use in the future, plus with the home icon, H seems more consistent. See: https://github.com/allen-cell-animated/simularium-website/issues/139#issuecomment-866280439

Solution
========
Changed tooltip to "Home view (H)" and changed hotkey to "H"
