### PR TITLE
PR template - use bullets instead of checkboxes under "Type of change"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,11 +12,11 @@ with @pairperson1
 ## Type of change
 Please delete options that are not relevant.
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-- [ ] This change requires updated or new tests
+* Bug fix (non-breaking change which fixes an issue)
+* New feature (non-breaking change which adds functionality)
+* Breaking change (fix or feature that would cause existing functionality to not work as expected)
+* This change requires a documentation update
+* This change requires updated or new tests
 
 Change summary:
 ---------------


### PR DESCRIPTION
Checkboxes in PRs make GitHub interpret them as tasks to be completed and displays a distracting blue circle, so using plain bullets instead. If approved I will go ahead and commit this change to simularium-viewer as well.