### PR TITLE
Fix/excessively wide time input box

### DIFF
--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -104,7 +104,7 @@ const PlayBackControls = ({
     const getTimeInputWidth = (): string => {
         // If maxNumChars is 5 then the input box width will be 6 character widths long
         // (+ 1 is arbitrary padding)
-        return displayTimes.maxNumChars + 1 + "ch";
+        return `${displayTimes.maxNumChars + 1}ch`;
     };
 
     const btnClassNames = classNames([styles.item, styles.btn]);

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -107,8 +107,18 @@ const PlayBackControls = ({
         // the max number of characters for this trajectory
         const refTimeValue =
             displayTimes.roundedLastFrameTime + displayTimes.roundedTimeStep;
-        const roundedRefTime = roundTimeForDisplay(refTimeValue);
-        const maxNumChars = roundedRefTime.toString().length;
+        const roundedRefTime = roundTimeForDisplay(refTimeValue).toString();
+
+        // Edge case: firstFrameTime is a very small but long number like this 0.000008,
+        // so we need to accommodate that.
+        const roundedFirstFrameTime = roundTimeForDisplay(
+            firstFrameTime
+        ).toString();
+        const maxNumChars = Math.max(
+            roundedFirstFrameTime.length,
+            roundedRefTime.length
+        );
+
         // If maxNumChars is 5 then the input box width will be 6 character widths long
         // (+ 1 is arbitrary padding)
         return maxNumChars + 1 + "ch";

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -6,7 +6,6 @@ import { TOOLTIP_COLOR } from "../../constants/index";
 import Icons from "../Icons";
 import { DisplayTimes } from "../../containers/ViewerPanel/types";
 import { TimeUnits } from "../../state/metadata/types";
-import { roundTimeForDisplay } from "../../util";
 
 const styles = require("./style.css");
 interface PlayBackProps {
@@ -101,7 +100,7 @@ const PlayBackControls = ({
         }
     };
 
-    // Determine the width of the input box
+    // Determine the width of the input box based on a likely max number of characters
     const getTimeInputWidth = (): string => {
         // If maxNumChars is 5 then the input box width will be 6 character widths long
         // (+ 1 is arbitrary padding)

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -6,6 +6,7 @@ import { TOOLTIP_COLOR } from "../../constants/index";
 import Icons from "../Icons";
 import { DisplayTimes } from "../../containers/ViewerPanel/types";
 import { TimeUnits } from "../../state/metadata/types";
+import { roundTimeForDisplay } from "../../util";
 
 const styles = require("./style.css");
 interface PlayBackProps {
@@ -106,7 +107,8 @@ const PlayBackControls = ({
         // the max number of characters for this trajectory
         const refTimeValue =
             displayTimes.roundedLastFrameTime + displayTimes.roundedTimeStep;
-        const maxNumChars = refTimeValue.toString().length;
+        const roundedRefTime = roundTimeForDisplay(refTimeValue);
+        const maxNumChars = roundedRefTime.toString().length;
         // If maxNumChars is 5 then the input box width will be 6 character widths long
         // (+ 1 is arbitrary padding)
         return maxNumChars + 1 + "ch";

--- a/src/components/PlaybackControls/index.tsx
+++ b/src/components/PlaybackControls/index.tsx
@@ -103,25 +103,9 @@ const PlayBackControls = ({
 
     // Determine the width of the input box
     const getTimeInputWidth = (): string => {
-        // If lastFrameTime is 15 and step size is 0.25 then 15.25 is probably going to have
-        // the max number of characters for this trajectory
-        const refTimeValue =
-            displayTimes.roundedLastFrameTime + displayTimes.roundedTimeStep;
-        const roundedRefTime = roundTimeForDisplay(refTimeValue).toString();
-
-        // Edge case: firstFrameTime is a very small but long number like this 0.000008,
-        // so we need to accommodate that.
-        const roundedFirstFrameTime = roundTimeForDisplay(
-            firstFrameTime
-        ).toString();
-        const maxNumChars = Math.max(
-            roundedFirstFrameTime.length,
-            roundedRefTime.length
-        );
-
         // If maxNumChars is 5 then the input box width will be 6 character widths long
         // (+ 1 is arbitrary padding)
-        return maxNumChars + 1 + "ch";
+        return displayTimes.maxNumChars + 1 + "ch";
     };
 
     const btnClassNames = classNames([styles.item, styles.btn]);

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -14,6 +14,7 @@ import {
     AgentColorMap,
     VisibilitySelectionMap,
 } from "../../state/selection/types";
+import { roundTimeForDisplay } from "../../util";
 import { DisplayTimes } from "./types";
 
 export const getSelectionStateInfoForViewer = createSelector(
@@ -60,18 +61,20 @@ export const getDisplayTimes = createSelector(
         getLastFrameTimeOfCachedSimulation,
     ],
     (time, timeUnits, timeStep, lastFrameTime): DisplayTimes => {
-        const roundNumber = (num: number) =>
-            parseFloat(Number(num).toPrecision(3));
         let roundedTime = 0;
         let roundedLastFrameTime = 0;
         let roundedTimeStep = 0;
 
         if (timeUnits) {
-            roundedTime = time ? roundNumber(time * timeUnits.magnitude) : 0;
-            roundedLastFrameTime = roundNumber(
+            roundedTime = time
+                ? roundTimeForDisplay(time * timeUnits.magnitude)
+                : 0;
+            roundedLastFrameTime = roundTimeForDisplay(
                 lastFrameTime * timeUnits.magnitude
             );
-            roundedTimeStep = roundNumber(timeStep * timeUnits.magnitude);
+            roundedTimeStep = roundTimeForDisplay(
+                timeStep * timeUnits.magnitude
+            );
         }
 
         return {

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -54,19 +54,19 @@ export const convertUIDataToColorMap = (
     }, returnData);
 };
 
-// Determine the width of the input box
+// Determine the likely max number of characters for the time input box
 const getMaxNumChars = (
     firstFrameTime: number,
     lastFrameTime: number,
     timeStep: number
 ) => {
-    // If lastFrameTime is 15 and step size is 0.25 then 15.25 is probably going to have
+    // If lastFrameTime is 15 and step size is 0.2 then 15.2 is probably going to have
     // the max number of characters for this trajectory
     const refTimeValue = lastFrameTime + timeStep;
     const roundedRefTime = roundTimeForDisplay(refTimeValue).toString();
 
-    // Edge case: firstFrameTime is a very small but long number like this 0.000008,
-    // so we need to accommodate that.
+    // Edge case: If firstFrameTime is a very small but long number like 0.000008,
+    // we need to accommodate that.
     const maxNumChars = Math.max(
         firstFrameTime.toString().length,
         roundedRefTime.length

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -55,7 +55,7 @@ export const convertUIDataToColorMap = (
 };
 
 // Determine the likely max number of characters for the time input box
-const getMaxNumChars = (
+export const getMaxNumChars = (
     firstFrameTime: number,
     lastFrameTime: number,
     timeStep: number

--- a/src/containers/ViewerPanel/test/selectors.test.ts
+++ b/src/containers/ViewerPanel/test/selectors.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import { initialState } from "../../../state/index";
 import { State } from "../../../state/types";
-import { getDisplayTimes } from "../selectors";
+import { getDisplayTimes, getMaxNumChars } from "../selectors";
 
 describe("ViewerPanel selectors", () => {
     describe("getDisplayTimes", () => {
@@ -105,6 +105,64 @@ describe("ViewerPanel selectors", () => {
                 roundedTimeStep: 0.08,
                 maxNumChars: 8,
             });
+        });
+    });
+
+    describe("getMaxNumChars", () => {
+        it("determines correct maxNumChars when time values are simple integers", () => {
+            const firstFrameTime = 0;
+            const lastFrameTime = 10;
+            const timeStep = 1;
+
+            const maxNumChars = getMaxNumChars(
+                firstFrameTime,
+                lastFrameTime,
+                timeStep
+            );
+
+            expect(maxNumChars).to.equal(2); // "11".length()
+        });
+
+        it("determines correct maxNumChars when time values are floats", () => {
+            const firstFrameTime = 0.1;
+            const lastFrameTime = 44.1;
+            const timeStep = 0.8;
+
+            const maxNumChars = getMaxNumChars(
+                firstFrameTime,
+                lastFrameTime,
+                timeStep
+            );
+
+            expect(maxNumChars).to.equal(4); // "44.9".length()
+        });
+
+        it("determines correct maxNumChars when time values are lengthy floats", () => {
+            const firstFrameTime = 0.1;
+            const lastFrameTime = 44.10006;
+            const timeStep = 0.0003;
+
+            const maxNumChars = getMaxNumChars(
+                firstFrameTime,
+                lastFrameTime,
+                timeStep
+            );
+
+            expect(maxNumChars).to.equal(4); // "44.1".length()
+        });
+
+        it("determines correct maxNumChars when firstFrameTime is very small and long", () => {
+            const firstFrameTime = 0.00001;
+            const lastFrameTime = 44.1;
+            const timeStep = 0.8;
+
+            const maxNumChars = getMaxNumChars(
+                firstFrameTime,
+                lastFrameTime,
+                timeStep
+            );
+
+            expect(maxNumChars).to.equal(7); // "0.00001".length()
         });
     });
 });

--- a/src/containers/ViewerPanel/test/selectors.test.ts
+++ b/src/containers/ViewerPanel/test/selectors.test.ts
@@ -103,7 +103,7 @@ describe("ViewerPanel selectors", () => {
                 roundedTime: 3,
                 roundedLastFrameTime: 15,
                 roundedTimeStep: 0.08,
-                maxNumChars: 8,
+                maxNumChars: "0.000004".length,
             });
         });
     });
@@ -120,7 +120,7 @@ describe("ViewerPanel selectors", () => {
                 timeStep
             );
 
-            expect(maxNumChars).to.equal(2); // "11".length()
+            expect(maxNumChars).to.equal("11".length);
         });
 
         it("determines correct maxNumChars when time values are floats", () => {
@@ -134,7 +134,7 @@ describe("ViewerPanel selectors", () => {
                 timeStep
             );
 
-            expect(maxNumChars).to.equal(4); // "44.9".length()
+            expect(maxNumChars).to.equal("44.9".length);
         });
 
         it("determines correct maxNumChars when time values are lengthy floats", () => {
@@ -148,7 +148,7 @@ describe("ViewerPanel selectors", () => {
                 timeStep
             );
 
-            expect(maxNumChars).to.equal(4); // "44.1".length()
+            expect(maxNumChars).to.equal("44.1".length);
         });
 
         it("determines correct maxNumChars when firstFrameTime is very small and long", () => {
@@ -162,7 +162,7 @@ describe("ViewerPanel selectors", () => {
                 timeStep
             );
 
-            expect(maxNumChars).to.equal(7); // "0.00001".length()
+            expect(maxNumChars).to.equal("0.00001".length);
         });
     });
 });

--- a/src/containers/ViewerPanel/test/selectors.test.ts
+++ b/src/containers/ViewerPanel/test/selectors.test.ts
@@ -109,7 +109,7 @@ describe("ViewerPanel selectors", () => {
     });
 
     describe("getMaxNumChars", () => {
-        it("determines correct maxNumChars when time values are simple integers", () => {
+        it("returns length of lastFrameTime + timeStep when time values are integers", () => {
             const firstFrameTime = 0;
             const lastFrameTime = 10;
             const timeStep = 1;
@@ -123,7 +123,7 @@ describe("ViewerPanel selectors", () => {
             expect(maxNumChars).to.equal("11".length);
         });
 
-        it("determines correct maxNumChars when time values are floats", () => {
+        it("returns length of lastFrameTime + timeStep when time values are floats", () => {
             const firstFrameTime = 0.1;
             const lastFrameTime = 44.1;
             const timeStep = 0.8;
@@ -137,7 +137,7 @@ describe("ViewerPanel selectors", () => {
             expect(maxNumChars).to.equal("44.9".length);
         });
 
-        it("determines correct maxNumChars when time values are lengthy floats", () => {
+        it("returns length of lastFrameTime + timeStep when time values are lengthy floats that need rounding at the end", () => {
             const firstFrameTime = 0.1;
             const lastFrameTime = 44.10006;
             const timeStep = 0.0003;
@@ -151,7 +151,7 @@ describe("ViewerPanel selectors", () => {
             expect(maxNumChars).to.equal("44.1".length);
         });
 
-        it("determines correct maxNumChars when firstFrameTime is very small and long", () => {
+        it("returns length of firstFrameTime when it is longer than lastFrameTime + timeStep", () => {
             const firstFrameTime = 0.00001;
             const lastFrameTime = 44.1;
             const timeStep = 0.8;

--- a/src/containers/ViewerPanel/test/selectors.test.ts
+++ b/src/containers/ViewerPanel/test/selectors.test.ts
@@ -16,6 +16,7 @@ describe("ViewerPanel selectors", () => {
                 roundedTime: 0,
                 roundedLastFrameTime: 0,
                 roundedTimeStep: 0,
+                maxNumChars: 1,
             });
         });
 
@@ -34,6 +35,7 @@ describe("ViewerPanel selectors", () => {
                     },
                     timeStep: 0.100000000023,
                     lastFrameTime: 15.0001,
+                    firstFrameTime: 0.1000000001,
                 },
             };
 
@@ -43,6 +45,7 @@ describe("ViewerPanel selectors", () => {
                 roundedTime: 3,
                 roundedLastFrameTime: 15,
                 roundedTimeStep: 0.1,
+                maxNumChars: 4,
             });
         });
 
@@ -61,6 +64,7 @@ describe("ViewerPanel selectors", () => {
                     },
                     timeStep: 0.100000000023,
                     lastFrameTime: 15.0001,
+                    firstFrameTime: 0.1000000001,
                 },
             };
 
@@ -70,6 +74,36 @@ describe("ViewerPanel selectors", () => {
                 roundedTime: 6,
                 roundedLastFrameTime: 30,
                 roundedTimeStep: 0.2,
+                maxNumChars: 4,
+            });
+        });
+
+        it("shows correct maxNumChars when firstFrameTime is very long", () => {
+            const mockState: State = {
+                ...initialState,
+                selection: {
+                    ...initialState.selection,
+                    time: 3.0001,
+                },
+                metadata: {
+                    ...initialState.metadata,
+                    timeUnits: {
+                        magnitude: 1,
+                        name: "ns",
+                    },
+                    timeStep: 0.0800000000023,
+                    lastFrameTime: 15.0001,
+                    firstFrameTime: 0.000004000000001,
+                },
+            };
+
+            const displayTimes = getDisplayTimes(mockState);
+
+            expect(displayTimes).to.deep.equal({
+                roundedTime: 3,
+                roundedLastFrameTime: 15,
+                roundedTimeStep: 0.08,
+                maxNumChars: 8,
             });
         });
     });

--- a/src/containers/ViewerPanel/types.ts
+++ b/src/containers/ViewerPanel/types.ts
@@ -2,4 +2,5 @@ export interface DisplayTimes {
     roundedTime: number;
     roundedLastFrameTime: number;
     roundedTimeStep: number;
+    maxNumChars: number;
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -76,3 +76,7 @@ export const wrapText = (
 export const clearUrlParams = () => {
     history.replaceState({}, "", `${location.origin}${location.pathname}`);
 };
+
+export const roundTimeForDisplay = (time: number): number => {
+    return parseFloat(time.toPrecision(3));
+};

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -1,7 +1,12 @@
 import { expect } from "chai";
 import * as React from "react";
 
-import { bindAll, convertToSentenceCase, wrapText } from "../";
+import {
+    bindAll,
+    convertToSentenceCase,
+    roundTimeForDisplay,
+    wrapText,
+} from "../";
 import {
     getGoogleDriveFileId,
     getUserTrajectoryUrl,
@@ -102,6 +107,30 @@ describe("General utilities", () => {
                 formattedText: "123 567<br>890<br>abcdefg<br>wxyz",
                 numLines: 4,
             });
+        });
+    });
+
+    describe("roundTimeForDisplay", () => {
+        it("returns a float with the requisite number of sig figs as is", () => {
+            expect(roundTimeForDisplay(1.23)).to.equal(1.23);
+        });
+        it("returns a float with less than the requisite number of sig figs as is", () => {
+            expect(roundTimeForDisplay(1.2)).to.equal(1.2);
+        });
+        it("rounds a float with greater than the requisite number of sig figs", () => {
+            expect(roundTimeForDisplay(1.234123)).to.equal(1.23);
+        });
+        it("returns an integer with the requisite number of sig figs as is", () => {
+            expect(roundTimeForDisplay(123)).to.equal(123);
+        });
+        it("returns an integer with less than the requisite number of sig figs as is", () => {
+            expect(roundTimeForDisplay(12)).to.equal(12);
+        });
+        it("rounds an integer with greater than the requisite number of sig figs", () => {
+            expect(roundTimeForDisplay(1234123)).to.equal(1230000);
+        });
+        it("does not include unnecessary zeros", () => {
+            expect(roundTimeForDisplay(1.20000001)).to.equal(1.2);
         });
     });
 });


### PR DESCRIPTION
Problem
=======
Resolves #158 

Solution
========
Two fixes needed to be made to address the above bug with Membrane Wrapping a Nanoparticle:
1. Round the `refTimeValue` (`lastFrameTime + timeStep`) before determining its character length, because 5.44 + 0.08 = 5.520000000212455 of course
2. If the firstFrameTime is a very small (and long) number like 0.0008 (longer than `refTimeValue`), the input box needs to be long enough to accommodate that

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* This change requires updated or new tests

Steps to Verify:
----------------
1. `npm start` and load Membrane Wrapping a Nanoparticle
2. The time input box should have sufficient (but not excessive) width to display the current time value at all times
3. Check the other networked trajectories

Screenshots (optional):
-----------------------
Before:
![image](https://user-images.githubusercontent.com/12690133/124335097-fdaefb00-db4d-11eb-8e1e-425b6d2d1968.png)

After:
![image](https://user-images.githubusercontent.com/12690133/124335076-ef60df00-db4d-11eb-9590-963e4c313c53.png)

Keyfiles (delete if not relevant):
-----------------------
* src/containers/ViewerPanel/selectors.ts - I moved the logic in `getTimeInputWidth` from PlaybackControls into here (as `getMaxNumChars`), and made it a function that the `getDisplayTimes` selector calls. `getMaxNumChars` now has the fixes described under "Solution".
* src/util/index.ts - I moved the `roundNumber` function from the `getDisplayTimes` selector into here and made it a util function that's called whenever we need to round a time value for display.