### PR TITLE
Change references to master branch to main

### DIFF
--- a/.github/workflows/auto-deploy-staging.yml
+++ b/.github/workflows/auto-deploy-staging.yml
@@ -6,7 +6,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ ___
 1. Fork the repo on GitHub.
 2. Create a branch and make your edits on your branch, pushing back to your fork.
 3. Make sure `npm run typeCheck`, `npm run test` and `npm run lint` all exit without errors. Add tests and documentation as needed.
-4. Submit a pull request back to master via GitHub using template, include screen shots for visual changes. 
+4. Submit a pull request back to main via GitHub using template, include screen shots for visual changes. 
 
 
 ### Structure
@@ -61,11 +61,11 @@ and b) copying the contents of the artifact to an S3 website bucket. For both st
 steps are captured in this project's Jenkinsfile and can be executed by setting the proper parameters for the Jenkins build.
 
 #### Staging deployment
-Automatically builds from `master`
+Automatically builds from `main`
 
 #### Production deployment
 1. Make a new version: `npm version [patch/minor/major]`
-2. Push the new package.json version: `git push origin master`
+2. Push the new package.json version: `git push origin main`
 3. Push the new tag: `git push origin [NEW_TAG]`
 
 ### Docker image configuration

--- a/src/components/TutorialPage/index.tsx
+++ b/src/components/TutorialPage/index.tsx
@@ -112,7 +112,7 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                                 <li>
                                     These{" "}
                                     <a
-                                        href="https://github.com/allen-cell-animated/simulariumio/tree/master/examples"
+                                        href="https://github.com/allen-cell-animated/simulariumio/tree/main/examples"
                                         target="_blank"
                                         rel="noopener noreferrer"
                                     >
@@ -153,7 +153,7 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                                         {SUPPORTED_ENGINES.map(
                                             (engine: string[]) => {
                                                 const name = engine[0];
-                                                const url = `https://github.com/allen-cell-animated/simulariumio/blob/master/examples/Tutorial_${name.toLowerCase()}.ipynb`;
+                                                const url = `https://github.com/allen-cell-animated/simulariumio/blob/main/examples/Tutorial_${name.toLowerCase()}.ipynb`;
                                                 return (
                                                     <li key={name}>
                                                         <a
@@ -174,7 +174,7 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                                     your data, choose the notebook for
                                     converting{" "}
                                     <a
-                                        href="https://github.com/allen-cell-animated/simulariumio/blob/master/examples/Tutorial_custom.ipynb"
+                                        href="https://github.com/allen-cell-animated/simulariumio/blob/main/examples/Tutorial_custom.ipynb"
                                         target="_blank"
                                         rel="noopener noreferrer"
                                     >


### PR DESCRIPTION
Problem
=======
I changed the master branch for simularium-website, viewer, and simulariumio to `main` but there are references to `master` in this repo.

Solution
========
I replaced all the references to the master branch (of this repo and to simulariumio's) in this repository. I left the references in gradle and jenkins files as they are, since we're planning to get rid of them soon.

FYI, all URLs to a repo's master branch (like https://github.com/allen-cell-animated/simulariumio/blob/master/examples/Tutorial_custom.ipynb) automatically redirect to the main branch, so it's not a worry. But I swapped them out in _src/components/TutorialPage/index.tsx_ anyway because why not.

Steps to Verify:
----------------
1. Pull this branch and do a global search for `master` and verify that all the occurrences that need updating to `main` are updated.
