### PR TITLE
Fix/remove CopyWebpackPlugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,6 @@
                 "babel-loader": "8.0.5",
                 "babel-plugin-import": "1.11.0",
                 "clean-webpack-plugin": "1.0.1",
-                "copy-webpack-plugin": "^5.0.4",
                 "css-loader": "2.1.0",
                 "dotenv": "^10.0.0",
                 "enzyme": "3.9.0",
@@ -6221,69 +6220,6 @@
                 "toggle-selection": "^1.0.6"
             }
         },
-        "node_modules/copy-webpack-plugin": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
-            "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
-            "dev": true,
-            "dependencies": {
-                "cacache": "^12.0.3",
-                "find-cache-dir": "^2.1.0",
-                "glob-parent": "^3.1.0",
-                "globby": "^7.1.1",
-                "is-glob": "^4.0.1",
-                "loader-utils": "^1.2.3",
-                "minimatch": "^3.0.4",
-                "normalize-path": "^3.0.0",
-                "p-limit": "^2.2.1",
-                "schema-utils": "^1.0.0",
-                "serialize-javascript": "^4.0.0",
-                "webpack-log": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 6.9.0"
-            }
-        },
-        "node_modules/copy-webpack-plugin/node_modules/json5": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
-            }
-        },
-        "node_modules/copy-webpack-plugin/node_modules/loader-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-            "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-            "dev": true,
-            "dependencies": {
-                "ajv": "^6.1.0",
-                "ajv-errors": "^1.0.0",
-                "ajv-keywords": "^3.1.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/core-js": {
             "version": "2.5.5",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
@@ -7103,18 +7039,6 @@
                 "bn.js": "^4.1.0",
                 "miller-rabin": "^4.0.0",
                 "randombytes": "^2.0.0"
-            }
-        },
-        "node_modules/dir-glob": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-            "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-            "dev": true,
-            "dependencies": {
-                "path-type": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/discontinuous-range": {
@@ -9768,41 +9692,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/globby": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-            "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^1.0.1",
-                "dir-glob": "^2.0.0",
-                "glob": "^7.1.2",
-                "ignore": "^3.3.5",
-                "pify": "^3.0.0",
-                "slash": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/globby/node_modules/pify": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/globby/node_modules/slash": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/glsl-inject-defines": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
@@ -10751,12 +10640,6 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
             "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-            "dev": true
-        },
-        "node_modules/ignore": {
-            "version": "3.3.10",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
             "dev": true
         },
         "node_modules/image-palette": {
@@ -17430,27 +17313,6 @@
             "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
             "dependencies": {
                 "isarray": "0.0.1"
-            }
-        },
-        "node_modules/path-type": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-            "dev": true,
-            "dependencies": {
-                "pify": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/path-type/node_modules/pify": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/pbf": {
@@ -29627,59 +29489,6 @@
                 "toggle-selection": "^1.0.6"
             }
         },
-        "copy-webpack-plugin": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
-            "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
-            "dev": true,
-            "requires": {
-                "cacache": "^12.0.3",
-                "find-cache-dir": "^2.1.0",
-                "glob-parent": "^3.1.0",
-                "globby": "^7.1.1",
-                "is-glob": "^4.0.1",
-                "loader-utils": "^1.2.3",
-                "minimatch": "^3.0.4",
-                "normalize-path": "^3.0.0",
-                "p-limit": "^2.2.1",
-                "schema-utils": "^1.0.0",
-                "serialize-javascript": "^4.0.0",
-                "webpack-log": "^2.0.0"
-            },
-            "dependencies": {
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
-                },
-                "schema-utils": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-errors": "^1.0.0",
-                        "ajv-keywords": "^3.1.0"
-                    }
-                }
-            }
-        },
         "core-js": {
             "version": "2.5.5",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
@@ -30393,15 +30202,6 @@
                 "bn.js": "^4.1.0",
                 "miller-rabin": "^4.0.0",
                 "randombytes": "^2.0.0"
-            }
-        },
-        "dir-glob": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-            "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-            "dev": true,
-            "requires": {
-                "path-type": "^3.0.0"
             }
         },
         "discontinuous-range": {
@@ -32729,34 +32529,6 @@
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
         },
-        "globby": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-            "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-            "dev": true,
-            "requires": {
-                "array-union": "^1.0.1",
-                "dir-glob": "^2.0.0",
-                "glob": "^7.1.2",
-                "ignore": "^3.3.5",
-                "pify": "^3.0.0",
-                "slash": "^1.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                },
-                "slash": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-                    "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-                    "dev": true
-                }
-            }
-        },
         "glsl-inject-defines": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
@@ -33598,12 +33370,6 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
             "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-            "dev": true
-        },
-        "ignore": {
-            "version": "3.3.10",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
             "dev": true
         },
         "image-palette": {
@@ -38888,23 +38654,6 @@
             "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
             "requires": {
                 "isarray": "0.0.1"
-            }
-        },
-        "path-type": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-            "dev": true,
-            "requires": {
-                "pify": "^3.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                }
             }
         },
         "pbf": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "babel-loader": "8.0.5",
         "babel-plugin-import": "1.11.0",
         "clean-webpack-plugin": "1.0.1",
-        "copy-webpack-plugin": "^5.0.4",
         "css-loader": "2.1.0",
         "dotenv": "^10.0.0",
         "enzyme": "3.9.0",

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -6,7 +6,6 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const webpack = require('webpack');
 

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -51,9 +51,6 @@ const PLUGINS_BY_ENV = {
         })
     ],
     [Env.DEVELOPMENT]: [
-        new CopyWebpackPlugin([
-            { from: 'src/data', to: 'api/v1' }
-        ]),
         new webpack.EnvironmentPlugin({
             BACKEND_SERVER_IP: `dev-node1-agentviz-backend.cellexplore.net`
         })


### PR DESCRIPTION
Problem
=======
We removed src/data which contained a copy of some plot data that we don't use anymore, and now webpack complains about it because we're doing something (I guess copying) with it with the CopyWebpackPlugin in our dev env config. 

Solution
========
Remove all traces of copy-webpack-plugin (because it was only used for this src/data directory)

(I suspect there are multiple other dependencies that we no longer use, so I want to do a general dependency cleanup soon too)

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Pull the branch, `npm start`, make sure the app still builds and runs successfully and that there is no webpack warning about src/data in the console anymore