### PR TITLE
Feature/let user know in tutorial and error message that Google Drive is supported

### DIFF
--- a/src/components/TutorialPage/index.tsx
+++ b/src/components/TutorialPage/index.tsx
@@ -209,8 +209,9 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                     <ol>
                         <li>
                             Upload your Simularium file to one of the supported
-                            public cloud providers, currently Dropbox or Amazon
-                            S3, and get a publicly accessible link to the file.
+                            public cloud providers, currently Dropbox, Google
+                            Drive, or Amazon S3, and get a publicly accessible
+                            link to the file.
                         </li>
                         <li>
                             In a supported browser, navigate to{" "}

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -285,7 +285,7 @@ const loadFileViaUrl = createLogic({
                 // If there was a CORS error, error.message does not contain a status code
                 if (error.message === "Failed to fetch") {
                     errorDetails +=
-                        "<br/><br/>Try uploading your trajectory file from a Dropbox or Amazon S3 link instead.";
+                        "<br/><br/>Try uploading your trajectory file from a Dropbox, Google Drive, or Amazon S3 link instead.";
                 }
                 dispatch(
                     setViewerStatus({


### PR DESCRIPTION
Problem
=======
Closes #214 

Solution
========
Added "Google Drive" to our tutorial page and to the error message that pops up when someone uses a non-supported cloud storage link as a trajUrl param.

I guess someday we could have a global constant that keeps track of which providers we support, but seems a bit overkill for now?

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)