### PR TITLE
Fix/update SpringSaLaD publication and redirect related URLs

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -40,6 +40,8 @@ export const SUPPORTED_ENGINES = [
     ["MEDYAN", MEDYAN_URL],
 ];
 
+// If any these URLs are used as a trajUrl param, we want to redirect to a networked file
+// More info: https://github.com/allen-cell-animated/simularium-website/issues/213
 export const USER_TRAJ_REDIRECTS = [
     "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_Below_Ksp.simularium",
     "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_At_Ksp.simularium",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -39,3 +39,9 @@ export const SUPPORTED_ENGINES = [
     ["SpringSaLaD", SPRINGSALAD_URL],
     ["MEDYAN", MEDYAN_URL],
 ];
+
+export const USER_TRAJ_REDIRECTS = [
+    "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_Below_Ksp.simularium",
+    "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_At_Ksp.simularium",
+    "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_Above_Ksp.simularium",
+];

--- a/src/constants/networked-trajectories.ts
+++ b/src/constants/networked-trajectories.ts
@@ -223,10 +223,10 @@ const TRAJECTORIES: TrajectoryDisplayData[] = [
         authors: "Aniruddha Chattaraj et al.",
         publication: {
             title:
-                "Solubility product constant directs the formation of biomolecular condensates",
-            journal: "bioRxiv",
-            year: 2020,
-            url: "https://www.biorxiv.org/content/10.1101/2020.12.26.424446v2",
+                "The solubility product extends the buffering concept to heterotypic biomolecular condensates",
+            journal: "eLife",
+            year: 2021,
+            url: "https://elifesciences.org/articles/67176",
         },
         description:
             "A SpringSaLaD model of liquid-liquid phase separation below Ksp where no condensate forms.",
@@ -243,10 +243,10 @@ const TRAJECTORIES: TrajectoryDisplayData[] = [
         authors: "Aniruddha Chattaraj et al.",
         publication: {
             title:
-                "Solubility product constant directs the formation of biomolecular condensates",
-            journal: "bioRxiv",
-            year: 2020,
-            url: "https://www.biorxiv.org/content/10.1101/2020.12.26.424446v2",
+                "The solubility product extends the buffering concept to heterotypic biomolecular condensates",
+            journal: "eLife",
+            year: 2021,
+            url: "https://elifesciences.org/articles/67176",
         },
         description:
             "A SpringSaLaD model of liquid-liquid phase separation at Ksp where condensate forms.",
@@ -263,10 +263,10 @@ const TRAJECTORIES: TrajectoryDisplayData[] = [
         authors: "Aniruddha Chattaraj et al.",
         publication: {
             title:
-                "Solubility product constant directs the formation of biomolecular condensates",
-            journal: "bioRxiv",
-            year: 2020,
-            url: "https://www.biorxiv.org/content/10.1101/2020.12.26.424446v2",
+                "The solubility product extends the buffering concept to heterotypic biomolecular condensates",
+            journal: "eLife",
+            year: 2021,
+            url: "https://elifesciences.org/articles/67176",
         },
         description:
             "A SpringSaLaD model of liquid-liquid phase separation above Ksp where condensate forms.",

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -39,7 +39,7 @@ import { clearUrlParams } from "../../util";
 import {
     getFileIdFromUrl,
     urlCheck,
-    getStreamingUrl,
+    getRedirectUrl,
 } from "../../util/userUrlHandling";
 const { Content } = Layout;
 
@@ -115,15 +115,12 @@ class App extends React.Component<AppProps, AppState> {
         ) => {
             const verifiedUrl = urlCheck(userTrajectoryUrl);
             const fileId = getFileIdFromUrl(verifiedUrl, parsed.id);
-            if (
-                verifiedUrl &&
-                fileId &&
-                USER_TRAJ_REDIRECTS.includes(verifiedUrl)
-            ) {
+            const redirectUrl = getRedirectUrl(verifiedUrl, fileId);
+
+            if (redirectUrl) {
                 // Edge case where we want to redirect to a networked file
-                const streamingUrl = getStreamingUrl(fileId);
-                history.replaceState({}, "", streamingUrl);
-                loadNetworkedFile(fileId);
+                history.replaceState({}, "", redirectUrl);
+                loadNetworkedFile(fileId as string);
             } else if (verifiedUrl) {
                 loadViaUrl(verifiedUrl, controller, fileId);
             } else {

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -118,7 +118,7 @@ class App extends React.Component<AppProps, AppState> {
             ) {
                 const streamingUrl = `${location.origin}${
                     location.pathname
-                }/trajFileName=${fileId}`;
+                }?trajFileName=${fileId}`;
                 history.replaceState({}, "", streamingUrl);
                 loadNetworkedFile(fileId);
             } else if (verifiedUrl) {

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -17,7 +17,6 @@ import selectionStateBranch from "../../state/selection";
 import {
     URL_PARAM_KEY_FILE_NAME,
     URL_PARAM_KEY_USER_URL,
-    USER_TRAJ_REDIRECTS,
 } from "../../constants";
 import {
     LoadViaUrlAction,

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -116,9 +116,11 @@ class App extends React.Component<AppProps, AppState> {
                 fileId &&
                 USER_TRAJ_REDIRECTS.includes(verifiedUrl)
             ) {
-                const streamingUrl = `${location.origin}${
-                    location.pathname
-                }?trajFileName=${fileId}`;
+                // Edge case where we want to redirect to a networked file
+                const streamingUrl =
+                    location.origin +
+                    location.pathname +
+                    `?trajFileName=${fileId}`;
                 history.replaceState({}, "", streamingUrl);
                 loadNetworkedFile(fileId);
             } else if (verifiedUrl) {
@@ -138,8 +140,10 @@ class App extends React.Component<AppProps, AppState> {
         };
 
         if (fileName) {
+            // URL has trajFileName param
             loadNetworkedFile(fileName);
         } else if (userTrajectoryUrl) {
+            // URL has trajUrl param
             loadUserTrajectoryUrl(userTrajectoryUrl);
         } else {
             setSimulariumController(controller);

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -36,7 +36,11 @@ import { VIEWER_ERROR, VIEWER_LOADING } from "../../state/metadata/constants";
 import TRAJECTORIES from "../../constants/networked-trajectories";
 import { TrajectoryDisplayData } from "../../constants/interfaces";
 import { clearUrlParams } from "../../util";
-import { getFileIdFromUrl, urlCheck } from "../../util/userUrlHandling";
+import {
+    getFileIdFromUrl,
+    urlCheck,
+    getStreamingUrl,
+} from "../../util/userUrlHandling";
 const { Content } = Layout;
 
 const styles = require("./style.css");
@@ -117,10 +121,7 @@ class App extends React.Component<AppProps, AppState> {
                 USER_TRAJ_REDIRECTS.includes(verifiedUrl)
             ) {
                 // Edge case where we want to redirect to a networked file
-                const streamingUrl =
-                    location.origin +
-                    location.pathname +
-                    `?trajFileName=${fileId}`;
+                const streamingUrl = getStreamingUrl(fileId);
                 history.replaceState({}, "", streamingUrl);
                 loadNetworkedFile(fileId);
             } else if (verifiedUrl) {

--- a/src/state/metadata/logics.ts
+++ b/src/state/metadata/logics.ts
@@ -262,14 +262,10 @@ const loadFileViaUrl = createLogic({
                 }
             })
             .then((json) => {
-                // ex) "mysite.com/myTraj.simularium?dl=0" -> ["mysite.com", "myTraj.simularium?dl=0"]
-                const urlSplit = url.split("/");
-                // ex) ["mysite.com", "myTraj.simularium?dl=0"] -> "myTraj.simularium"
-                const name = urlSplit[urlSplit.length - 1].split("?")[0];
                 dispatch(
                     changeToLocalSimulariumFile(
                         {
-                            name, //TODO: add this to metadata about the file
+                            name: action.fileId, //TODO: add this to metadata about the file
                             data: json,
                             // Temp solution: Set lastModified to a date in the future to tell this apart
                             // from legitimate lastModified values

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -10,7 +10,7 @@ import {
 import {
     getFileIdFromUrl,
     getGoogleDriveFileId,
-    getStreamingUrl,
+    getRedirectUrl,
     getUserTrajectoryUrl,
     isGoogleDriveUrl,
     urlCheck,
@@ -266,19 +266,19 @@ describe("User Url handling", () => {
         });
     });
 
-    describe("getStreamingUrl", () => {
-        it("replaces the trajUrl param in current location with a trajFileName param", () => {
-            window.history.replaceState(
-                {},
-                "",
-                "/viewer?trajUrl=https://myfile.com/myfile"
-            );
-            const streamingUrl = getStreamingUrl("endocytosis.simularium");
-            const expected =
-                "http://localhost/viewer?trajFileName=endocytosis.simularium";
-            expect(streamingUrl).toBe(expected);
-        });
-    });
+    // describe("getStreamingUrl", () => {
+    //     it("replaces the trajUrl param in current location with a trajFileName param", () => {
+    //         window.history.replaceState(
+    //             {},
+    //             "",
+    //             "/viewer?trajUrl=https://myfile.com/myfile"
+    //         );
+    //         const streamingUrl = getStreamingUrl("endocytosis.simularium");
+    //         const expected =
+    //             "http://localhost/viewer?trajFileName=endocytosis.simularium";
+    //         expect(streamingUrl).toBe(expected);
+    //     });
+    // });
 
     describe("getUserTrajectoryUrl", () => {
         it("returns a google api url if given an id and a google url", () => {

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { USER_TRAJ_REDIRECTS } from "../../constants";
 import {
     bindAll,
     convertToSentenceCase,
@@ -266,19 +267,24 @@ describe("User Url handling", () => {
         });
     });
 
-    // describe("getStreamingUrl", () => {
-    //     it("replaces the trajUrl param in current location with a trajFileName param", () => {
-    //         window.history.replaceState(
-    //             {},
-    //             "",
-    //             "/viewer?trajUrl=https://myfile.com/myfile"
-    //         );
-    //         const streamingUrl = getStreamingUrl("endocytosis.simularium");
-    //         const expected =
-    //             "http://localhost/viewer?trajFileName=endocytosis.simularium";
-    //         expect(streamingUrl).toBe(expected);
-    //     });
-    // });
+    describe("getRedirectUrl", () => {
+        it("returns empty string for a URL that shouldn't be redirected", () => {
+            const url =
+                "https://s3.amazonaws.com/trajectory/vivarium_ecoli.simularium";
+            const fileName = "vivarium_ecoli.simularium";
+            expect(getRedirectUrl(url, fileName)).toBe("");
+        });
+        it("replaces the trajUrl param in current URL with a trajFileName param if URL is listed in USER_TRAJ_REDIRECTS", () => {
+            const fileName = "testFileName";
+            const url = USER_TRAJ_REDIRECTS[0];
+            window.history.replaceState({}, "", `/viewer?trajUrl=${url}`);
+
+            const redirectUrl = getRedirectUrl(url, fileName);
+            const expected =
+                "http://localhost/viewer?trajFileName=testFileName";
+            expect(redirectUrl).toBe(expected);
+        });
+    });
 
     describe("getUserTrajectoryUrl", () => {
         it("returns a google api url if given an id and a google url", () => {

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -249,13 +249,19 @@ describe("User Url handling", () => {
     });
 
     describe("getFileIdFromUrl", () => {
-        it("returns nothing if the URL is not a Google Drive URL", () => {
-            const url = "https://dropbox.com/123456789";
-            expect(getFileIdFromUrl(url)).toBe(undefined);
-        });
         it("returns an id if the URL is a Google Drive URL", () => {
             const url = "https://drive.google.com/file/d/123456789";
             expect(getFileIdFromUrl(url)).toBe("123456789");
+        });
+        it("returns file name if the URL is not a Google Drive URL and has a query string", () => {
+            const url =
+                "https://s3.amazonaws.com/trajectory/vivarium_ecoli.simularium?city=seattle";
+            expect(getFileIdFromUrl(url)).toBe("vivarium_ecoli.simularium");
+        });
+        it("returns file name if the URL is not a Google Drive URL and does not have a query string", () => {
+            const url =
+                "https://s3.amazonaws.com/trajectory/vivarium_ecoli.simularium";
+            expect(getFileIdFromUrl(url)).toBe("vivarium_ecoli.simularium");
         });
     });
 

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -10,6 +10,7 @@ import {
 import {
     getFileIdFromUrl,
     getGoogleDriveFileId,
+    getStreamingUrl,
     getUserTrajectoryUrl,
     isGoogleDriveUrl,
     urlCheck,
@@ -262,6 +263,20 @@ describe("User Url handling", () => {
             const url =
                 "https://s3.amazonaws.com/trajectory/vivarium_ecoli.simularium";
             expect(getFileIdFromUrl(url)).toBe("vivarium_ecoli.simularium");
+        });
+    });
+
+    describe("getStreamingUrl", () => {
+        it("replaces the trajUrl param in current location with a trajFileName param", () => {
+            window.history.replaceState(
+                {},
+                "",
+                "/viewer?trajUrl=https://myfile.com/myfile"
+            );
+            const streamingUrl = getStreamingUrl("endocytosis.simularium");
+            const expected =
+                "http://localhost/viewer?trajFileName=endocytosis.simularium";
+            expect(streamingUrl).toBe(expected);
         });
     });
 

--- a/src/util/userUrlHandling.ts
+++ b/src/util/userUrlHandling.ts
@@ -63,6 +63,11 @@ export const getFileIdFromUrl = (
     }
 };
 
+export const getStreamingUrl = (fileId: string) => {
+    // ex) simularium.allencell.org/viewer?trajFileName=endocytosis.simularium
+    return `${location.origin}${location.pathname}?trajFileName=${fileId}`;
+};
+
 export const getGoogleApiUrl = (id: string) => {
     return `https://www.googleapis.com/drive/v2/files/${id}?alt=media&key=${
         process.env.GOOGLE_API_KEY

--- a/src/util/userUrlHandling.ts
+++ b/src/util/userUrlHandling.ts
@@ -57,6 +57,10 @@ export const getFileIdFromUrl = (
     // currently only id we're extracting from the url, but possible we'll need more
     if (isGoogleDriveUrl(url)) {
         return getGoogleDriveFileId(url, idParam);
+    } else {
+        // ex) "mysite.com/myTraj.simularium?dl=0" -> "myTraj.simularium"
+        const urlSplit = url.split("/");
+        return urlSplit[urlSplit.length - 1].split("?")[0];
     }
 };
 

--- a/src/util/userUrlHandling.ts
+++ b/src/util/userUrlHandling.ts
@@ -54,7 +54,6 @@ export const getFileIdFromUrl = (
     url: string,
     idParam?: string | string[] | null
 ) => {
-    // currently only id we're extracting from the url, but possible we'll need more
     if (isGoogleDriveUrl(url)) {
         return getGoogleDriveFileId(url, idParam);
     } else {

--- a/src/util/userUrlHandling.ts
+++ b/src/util/userUrlHandling.ts
@@ -1,5 +1,7 @@
 import { isString } from "lodash";
 
+import { USER_TRAJ_REDIRECTS } from "../constants";
+
 const googleDriveUrlRegEx = /(?:drive.google\.com\/file\/d\/)(.*)(?=\/)|(?:drive.google\.com\/file\/d\/)(.*)/g;
 const googleDriveUrlExcludingIdRegEx = /(drive.google\.com\/file\/d\/)(?=.*)/g;
 
@@ -63,9 +65,15 @@ export const getFileIdFromUrl = (
     }
 };
 
-export const getStreamingUrl = (fileId: string) => {
-    // ex) simularium.allencell.org/viewer?trajFileName=endocytosis.simularium
-    return `${location.origin}${location.pathname}?trajFileName=${fileId}`;
+export const getRedirectUrl = (url: string, fileName: string | undefined) => {
+    if (url && fileName && USER_TRAJ_REDIRECTS.includes(url)) {
+        // ex) simularium.allencell.org/viewer?trajFileName=endocytosis.simularium
+        return `${location.origin}${
+            location.pathname
+        }?trajFileName=${fileName}`;
+    } else {
+        return "";
+    }
 };
 
 export const getGoogleApiUrl = (id: string) => {


### PR DESCRIPTION
Problem
=======
There's a new SpringSaLaD publication out, and:

* The publication info for the posted SpringSaLaD trajectories is now outdated
* The published Simularium links to the trajectories have a `trajUrl` param that makes the client download the file from our S3 bucket. But we have these trajectories available for streaming now.

Closes #213 

Solution
========
* Update publication info for the SpringSaLaD trajectories
* Redirect the published SpringSaLaD `trajUrl` URLs to `trajFileName` URLs and stream the files instead of downloading them

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* This change requires updated or new tests

Steps to Verify:
----------------
1. Pull this branch and `npm start`
2. Click on a card from the landing page and verify it still loads as before
3. Drag and drop a trajectory and verify it still loads as before
4. Go to localhost:9001/viewer?trajUrl=https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/vivarium_ecoli.simularium and verify it still loads as before
3. Go to localhost:9001/viewer?trajUrl=https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/springsalad_condensate_formation_Below_Ksp.simularium and verify it redirects to localhost:9001/viewer?trajFileName=springsalad_condensate_formation_Below_Ksp.simularium and streams the file instead of downloading it to the client
