### PR TITLE
Replace agentviz with simularium in S3 URLs and in React app name

### DIFF
--- a/src/components/NoTrajectoriesText/NoTypeMappingText.tsx
+++ b/src/components/NoTrajectoriesText/NoTypeMappingText.tsx
@@ -10,7 +10,7 @@ const NoTypeMappingText: React.FunctionComponent<{}> = () => {
             <h3>Unable to load UI controls</h3>
             <p>
                 Review the{" "}
-                <a href="https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
+                <a href="https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
                     example data
                 </a>{" "}
                 or{" "}

--- a/src/components/NoTrajectoriesText/NoTypeMappingText.tsx
+++ b/src/components/NoTrajectoriesText/NoTypeMappingText.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { TUTORIAL_PATHNAME } from "../../routes";
+import { DATA_BUCKET_URL } from "../../constants";
 
 const styles = require("../NoTrajectoriesText/style.css");
 
@@ -10,7 +11,9 @@ const NoTypeMappingText: React.FunctionComponent<{}> = () => {
             <h3>Unable to load UI controls</h3>
             <p>
                 Review the{" "}
-                <a href="https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
+                <a
+                    href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
+                >
                     example data
                 </a>{" "}
                 or{" "}

--- a/src/components/NoTrajectoriesText/index.tsx
+++ b/src/components/NoTrajectoriesText/index.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { ActionCreator } from "redux";
 
 import { RequestNetworkFileAction } from "../../state/metadata/types";
-import { URL_PARAM_KEY_FILE_NAME } from "../../constants";
+import { URL_PARAM_KEY_FILE_NAME, DATA_BUCKET_URL } from "../../constants";
 import TRAJECTORIES from "../../constants/networked-trajectories";
 import { TrajectoryDisplayData } from "../../constants/interfaces";
 import { TUTORIAL_PATHNAME } from "../../routes";
@@ -28,7 +28,9 @@ const NoTrajectoriesText = ({ selectFile }: NoTrajectoriesTextProps) => {
             <h3>No trajectories loaded</h3>
             <p>
                 To view a simulation, either{" "}
-                <a href="https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
+                <a
+                    href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
+                >
                     download
                 </a>{" "}
                 our example data or{" "}

--- a/src/components/NoTrajectoriesText/index.tsx
+++ b/src/components/NoTrajectoriesText/index.tsx
@@ -28,7 +28,7 @@ const NoTrajectoriesText = ({ selectFile }: NoTrajectoriesTextProps) => {
             <h3>No trajectories loaded</h3>
             <p>
                 To view a simulation, either{" "}
-                <a href="https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
+                <a href="https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
                     download
                 </a>{" "}
                 our example data or{" "}

--- a/src/components/TutorialPage/index.tsx
+++ b/src/components/TutorialPage/index.tsx
@@ -21,7 +21,7 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                 <VisualGlossary />
                 <p className={styles.intro}>
                     To try out the Simularium Viewer, either{" "}
-                    <a href="https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
+                    <a href="https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
                         download
                     </a>{" "}
                     our example data or <a href="#convert-your-data">convert</a>{" "}
@@ -43,7 +43,7 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                     <ol>
                         <li>
                             Download the example data{" "}
-                            <a href="https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
+                            <a href="https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
                                 here
                             </a>
                             .

--- a/src/components/TutorialPage/index.tsx
+++ b/src/components/TutorialPage/index.tsx
@@ -5,7 +5,7 @@ import { Layout, Typography } from "antd";
 import dragDropImage from "../../assets/drag-drop.gif";
 import { VIEWER_PATHNAME } from "../../routes";
 import VisualGlossary from "../VisualGlossary";
-import { SUPPORTED_ENGINES } from "../../constants";
+import { SUPPORTED_ENGINES, DATA_BUCKET_URL } from "../../constants";
 import Footer from "../Footer";
 
 const { Content } = Layout;
@@ -21,7 +21,9 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                 <VisualGlossary />
                 <p className={styles.intro}>
                     To try out the Simularium Viewer, either{" "}
-                    <a href="https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
+                    <a
+                        href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
+                    >
                         download
                     </a>{" "}
                     our example data or <a href="#convert-your-data">convert</a>{" "}
@@ -43,7 +45,9 @@ const TutorialPage: React.FunctionComponent<{}> = () => {
                     <ol>
                         <li>
                             Download the example data{" "}
-                            <a href="https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium">
+                            <a
+                                href={`${DATA_BUCKET_URL}/trajectory/endocytosis.simularium`}
+                            >
                                 here
                             </a>
                             .

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-export const APP_ID = "agentviz-ui";
+export const APP_ID = "simularium-ui";
 export const API_VERSION = "v1";
 export const HEADER_HEIGHT = 113;
 export const URL_PARAM_KEY_FILE_NAME = "trajFileName";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,7 +11,7 @@ export const LEFT_PANEL_TOOLTIP_DELAY = 1; // in seconds
 
 // URLs
 export const BASE_API_URL = `/api/${API_VERSION}`;
-export const PLOT_DATA_URL =
+export const DATA_BUCKET_URL =
     "https://aics-simularium-data.s3.us-east-2.amazonaws.com";
 export const FORUM_URL =
     "https://forum.allencell.org/c/software-code/simularium/";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,7 +12,7 @@ export const LEFT_PANEL_TOOLTIP_DELAY = 1; // in seconds
 // URLs
 export const BASE_API_URL = `/api/${API_VERSION}`;
 export const PLOT_DATA_URL =
-    "https://aics-agentviz-data.s3.us-east-2.amazonaws.com";
+    "https://aics-simularium-data.s3.us-east-2.amazonaws.com";
 export const FORUM_URL =
     "https://forum.allencell.org/c/software-code/simularium/";
 // Note that below has "/tags/" unlike FORUM_URL

--- a/src/state/configure-store.ts
+++ b/src/state/configure-store.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { applyMiddleware, combineReducers, createStore } from "redux";
 import { createLogicMiddleware } from "redux-logic";
 
-import { BASE_API_URL, PLOT_DATA_URL } from "../constants";
+import { BASE_API_URL, DATA_BUCKET_URL } from "../constants";
 
 import { enableBatching, initialState, metadata, selection, State } from "./";
 
@@ -15,7 +15,7 @@ const logics = [...metadata.logics, ...selection.logics];
 
 const reduxLogicDependencies = {
     baseApiUrl: BASE_API_URL,
-    plotDataUrl: PLOT_DATA_URL,
+    plotDataUrl: DATA_BUCKET_URL,
     httpClient: axios,
 };
 

--- a/src/state/test/util.test.ts
+++ b/src/state/test/util.test.ts
@@ -14,7 +14,7 @@ describe("state utilities", () => {
             const constant = makeConstant("foo", "bar");
             const [namespace, reducer, type] = constant.split("/");
             expect(typeof constant).toBe("string");
-            expect(namespace).toBe("agentviz-ui");
+            expect(namespace).toBe("simularium-ui");
             expect(reducer).toBe("FOO");
             expect(type).toBe("BAR");
         });

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -175,8 +175,8 @@ describe("User Url handling", () => {
     describe("urlCheck", () => {
         it("returns strings that match the regex", () => {
             const shouldMatch = [
-                "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium",
-                "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.json",
+                "https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium",
+                "https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.json",
                 "http://web5-site.com/directory",
                 "https://fa-st.web9site.com/directory/file.filename",
                 "https://fa-st.web9site.com/directory-name/file.filename",
@@ -220,8 +220,8 @@ describe("User Url handling", () => {
     });
     it("returns false if the url doesn't have google.com in it", () => {
         const shouldNotMatch = [
-            "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium",
-            "https://aics-agentviz-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.json",
+            "https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.simularium",
+            "https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/endocytosis.json",
             "http://web5-site.com/directory",
             "https://fa-st.web9site.com/directory/file.filename",
             "https://fa-st.web9site.com/directory-name/file.filename",

--- a/webpack/index.template.html
+++ b/webpack/index.template.html
@@ -44,6 +44,6 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRGJTH2" height="0" width="0"
             style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
-    <main id="agentviz-ui"></main>
+    <main id="simularium-ui"></main>
 </body>
 </html>


### PR DESCRIPTION
Problem
=======
Closes #216 

Solution
========
1. Find and replace all instances of `agentviz` to `simularium` EXCEPT the backend server URLs - those have not been renamed (yet?). @EricJIsaac is this in your purview or is this for Chris E?
2. The above includes changing the [React?] app ID from `agentviz-ui` to `simularium-ui`
3. Rename the `PLOT_DATA_URL` constant as `DATA_BUCKET_URL` and use it in more places throughout

## Type of change
Please delete options that are not relevant.

* maintenance

Steps to Verify:
----------------
1. `npm start` and make sure app spins up, and that you can click the links that were renamed and get what you need
