### PR TITLE
Fix/selector code coverage

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,14 @@
+name: 'coverage'
+on:
+    pull_request:
+        branches:
+            - main
+jobs:
+    coverage:
+        runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        steps:
+            - uses: actions/checkout@v1
+            - uses: ArtiomTr/jest-coverage-report-action@v1.3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,20 +13,23 @@ module.exports = {
     },
     coverageThreshold: {
         "global": {
-            "branches": 50,
-            "functions": 50,
             "lines": 50,
             "statements": 50
         },
         "./src/state/*/selectors.ts": {
-            // "branches": 80,
             "lines": 60,
         },
         "./src/containers/*/selectors.ts": {
-            "branches": 50,
-            "functions": 50,
-            "lines": 50,
-            "statements": 50
+            "branches": 100,
+            "functions": 100,
+            "lines": 100,
+            "statements": 100
+        },
+        "./src/util": {
+            "branches": 100,
+            "functions": 100,
+            "lines": 100,
+            "statements": 100
         }
     }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,23 @@ module.exports = {
     moduleNameMapper: {
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/scripts/jestAssetTransformer.js",
         "\\.(css|less)$": "identity-obj-proxy"
+    },
+    coverageThreshold: {
+        "global": {
+            "branches": 50,
+            "functions": 50,
+            "lines": 50,
+            "statements": 50
+        },
+        "./src/state/*/selectors.ts": {
+            // "branches": 80,
+            "lines": 60,
+        },
+        "./src/containers/*/selectors.ts": {
+            "branches": 50,
+            "functions": 50,
+            "lines": 50,
+            "statements": 50
+        }
     }
 };

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -96,9 +96,7 @@ export const getDisplayTimes = createSelector(
         let roundedTimeStep = 0;
 
         if (timeUnits) {
-            roundedTime = time
-                ? roundTimeForDisplay(time * timeUnits.magnitude)
-                : 0;
+            roundedTime = roundTimeForDisplay(time * timeUnits.magnitude);
             roundedFirstFrameTime = roundTimeForDisplay(
                 firstFrameTime * timeUnits.magnitude
             );

--- a/src/containers/ViewerPanel/test/selectors.test.ts
+++ b/src/containers/ViewerPanel/test/selectors.test.ts
@@ -1,8 +1,86 @@
 import { initialState } from "../../../state/index";
 import { State } from "../../../state/types";
-import { getDisplayTimes, getMaxNumChars } from "../selectors";
+import {
+    convertUIDataToColorMap,
+    getDisplayTimes,
+    getMaxNumChars,
+} from "../selectors";
 
 describe("ViewerPanel selectors", () => {
+    describe("convertUIDataToColorMap", () => {
+        it("converts UI display data to color map where the agent name is the key, and the color is the value", () => {
+            const mockDisplayData = [
+                {
+                    name: "name",
+                    displayStates: [{ name: "state1", id: "id" }],
+                    color: "color",
+                },
+            ];
+            const result = convertUIDataToColorMap(mockDisplayData);
+            expect(result).toEqual({ name: "color" });
+        });
+        it("returns an empty object if no ui data present", () => {
+            const result = convertUIDataToColorMap([]);
+            expect(result).toEqual({});
+        });
+    });
+    describe("getMaxNumChars", () => {
+        it("returns length of lastFrameTime + timeStep when time values are integers", () => {
+            const firstFrameTime = 0;
+            const lastFrameTime = 10;
+            const timeStep = 1;
+
+            const maxNumChars = getMaxNumChars(
+                firstFrameTime,
+                lastFrameTime,
+                timeStep
+            );
+
+            expect(maxNumChars).toBe("11".length);
+        });
+
+        it("returns length of lastFrameTime + timeStep when time values are floats", () => {
+            const firstFrameTime = 0.1;
+            const lastFrameTime = 44.1;
+            const timeStep = 0.8;
+
+            const maxNumChars = getMaxNumChars(
+                firstFrameTime,
+                lastFrameTime,
+                timeStep
+            );
+
+            expect(maxNumChars).toBe("44.9".length);
+        });
+
+        it("returns length of lastFrameTime + timeStep when time values are lengthy floats that need rounding at the end", () => {
+            const firstFrameTime = 0.1;
+            const lastFrameTime = 44.10006;
+            const timeStep = 0.0003;
+
+            const maxNumChars = getMaxNumChars(
+                firstFrameTime,
+                lastFrameTime,
+                timeStep
+            );
+
+            expect(maxNumChars).toBe("44.1".length);
+        });
+
+        it("returns length of firstFrameTime when it is longer than lastFrameTime + timeStep", () => {
+            const firstFrameTime = 0.00001;
+            const lastFrameTime = 44.1;
+            const timeStep = 0.8;
+
+            const maxNumChars = getMaxNumChars(
+                firstFrameTime,
+                lastFrameTime,
+                timeStep
+            );
+
+            expect(maxNumChars).toBe("0.00001".length);
+        });
+    });
     describe("getDisplayTimes", () => {
         it("returns default values when timeUnits doesn't exist", () => {
             const mockState: State = initialState;
@@ -103,64 +181,6 @@ describe("ViewerPanel selectors", () => {
                 roundedTimeStep: 0.08,
                 maxNumChars: "0.000004".length,
             });
-        });
-    });
-
-    describe("getMaxNumChars", () => {
-        it("returns length of lastFrameTime + timeStep when time values are integers", () => {
-            const firstFrameTime = 0;
-            const lastFrameTime = 10;
-            const timeStep = 1;
-
-            const maxNumChars = getMaxNumChars(
-                firstFrameTime,
-                lastFrameTime,
-                timeStep
-            );
-
-            expect(maxNumChars).toBe("11".length);
-        });
-
-        it("returns length of lastFrameTime + timeStep when time values are floats", () => {
-            const firstFrameTime = 0.1;
-            const lastFrameTime = 44.1;
-            const timeStep = 0.8;
-
-            const maxNumChars = getMaxNumChars(
-                firstFrameTime,
-                lastFrameTime,
-                timeStep
-            );
-
-            expect(maxNumChars).toBe("44.9".length);
-        });
-
-        it("returns length of lastFrameTime + timeStep when time values are lengthy floats that need rounding at the end", () => {
-            const firstFrameTime = 0.1;
-            const lastFrameTime = 44.10006;
-            const timeStep = 0.0003;
-
-            const maxNumChars = getMaxNumChars(
-                firstFrameTime,
-                lastFrameTime,
-                timeStep
-            );
-
-            expect(maxNumChars).toBe("44.1".length);
-        });
-
-        it("returns length of firstFrameTime when it is longer than lastFrameTime + timeStep", () => {
-            const firstFrameTime = 0.00001;
-            const lastFrameTime = 44.1;
-            const timeStep = 0.8;
-
-            const maxNumChars = getMaxNumChars(
-                firstFrameTime,
-                lastFrameTime,
-                timeStep
-            );
-
-            expect(maxNumChars).toBe("0.00001".length);
         });
     });
 });

--- a/src/containers/ViewerPanel/test/selectors.test.ts
+++ b/src/containers/ViewerPanel/test/selectors.test.ts
@@ -4,9 +4,24 @@ import {
     convertUIDataToColorMap,
     getDisplayTimes,
     getMaxNumChars,
+    getSelectionStateInfoForViewer,
 } from "../selectors";
 
 describe("ViewerPanel selectors", () => {
+    describe("getSelectionStateInfoForViewer", () => {
+        it("gathers the highlighted agents and hidden agents", () => {
+            /**
+             * Only need to test the shape of the data, the selectors that
+             * generate the contents of the two lists are tested in state
+             */
+            const result = getSelectionStateInfoForViewer({ ...initialState });
+            expect(result).toEqual({
+                hiddenAgents: [],
+                highlightedAgents: [],
+            });
+        });
+    });
+
     describe("convertUIDataToColorMap", () => {
         it("converts UI display data to color map where the agent name is the key, and the color is the value", () => {
             const mockDisplayData = [

--- a/src/containers/ViewerPanel/test/selectors.test.ts
+++ b/src/containers/ViewerPanel/test/selectors.test.ts
@@ -2,10 +2,19 @@ import { initialState } from "../../../state/index";
 import { State } from "../../../state/types";
 import {
     convertUIDataToColorMap,
+    convertUIDataToSelectionData,
     getDisplayTimes,
     getMaxNumChars,
     getSelectionStateInfoForViewer,
 } from "../selectors";
+
+const mockDisplayData = [
+    {
+        name: "name1",
+        displayStates: [{ name: "state1", id: "id1" }],
+        color: "color1",
+    },
+];
 
 describe("ViewerPanel selectors", () => {
     describe("getSelectionStateInfoForViewer", () => {
@@ -22,17 +31,32 @@ describe("ViewerPanel selectors", () => {
         });
     });
 
-    describe("convertUIDataToColorMap", () => {
-        it("converts UI display data to color map where the agent name is the key, and the color is the value", () => {
-            const mockDisplayData = [
+    describe("convertUIDataToSelectionData", () => {
+        it("converts UI display data to map with agent name as the key, and an array of display state names is the value (adding the empty string for unmodified state", () => {
+            const result = convertUIDataToSelectionData(mockDisplayData);
+            expect(result).toEqual({ name1: ["", "state1"] });
+        });
+        it("returns an array with just the agent name if there are no display states for an agent", () => {
+            const mockDisplayDataNoStates = [
                 {
-                    name: "name",
-                    displayStates: [{ name: "state1", id: "id" }],
-                    color: "color",
+                    name: "name1",
+                    displayStates: [],
+                    color: "color1",
                 },
             ];
+            const result = convertUIDataToSelectionData(
+                mockDisplayDataNoStates
+            );
+            expect(result).toEqual({
+                name1: ["name1"],
+            });
+        });
+    });
+
+    describe("convertUIDataToColorMap", () => {
+        it("converts UI display data to color map where the agent name is the key, and the color is the value", () => {
             const result = convertUIDataToColorMap(mockDisplayData);
-            expect(result).toEqual({ name: "color" });
+            expect(result).toEqual({ name1: "color1" });
         });
         it("returns an empty object if no ui data present", () => {
             const result = convertUIDataToColorMap([]);

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -80,5 +80,8 @@ export const clearUrlParams = () => {
 };
 
 export const roundTimeForDisplay = (time: number): number => {
+    if (time === 0) {
+        return 0;
+    }
     return parseFloat(time.toPrecision(3));
 };

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -150,6 +150,9 @@ describe("General utilities", () => {
         it("returns a float with the requisite number of sig figs as is", () => {
             expect(roundTimeForDisplay(1.23)).toBe(1.23);
         });
+        it("returns zero if given zero", () => {
+            expect(roundTimeForDisplay(0)).toBe(0);
+        });
         it("returns a float with less than the requisite number of sig figs as is", () => {
             expect(roundTimeForDisplay(1.2)).toBe(1.2);
         });

--- a/src/util/test/index.test.ts
+++ b/src/util/test/index.test.ts
@@ -251,6 +251,15 @@ describe("User Url handling", () => {
 
             expect(getGoogleDriveFileId("url", id)).toEqual(id);
         });
+        it("returns undefined if not google drive url", () => {
+            const id = "id";
+            const urls = [
+                `https://blah/${id}/view`,
+                `https://amazon.com/${id}`,
+            ];
+            const result = urls.map((url) => getGoogleDriveFileId(url));
+            expect(result).toEqual(Array(urls.length).fill(undefined));
+        });
     });
 
     describe("getFileIdFromUrl", () => {


### PR DESCRIPTION
Problem
=======
This is a step towards #182 

Solution
========
I added coverage thresholds to our jest config, and decided to get the ones that were almost at 100% over the finish line. 
For one test we were just missing a branch where a ternary was false, so I moved that into the utility function instead. 
NOTE: this is branched from the github action branch, just trying to keep PRs small, but this should be merged second. 

## Type of change
Please delete options that are not relevant.

* maintenance 

Steps to Verify:
----------------
1. actions should all pass

