### PR TITLE
Rename some redundant variable names in state.viewer

### DIFF
--- a/src/components/ViewerOverlayTarget/index.tsx
+++ b/src/components/ViewerOverlayTarget/index.tsx
@@ -16,18 +16,18 @@ interface ViewerOverlayTargetProps {
     loadLocalFile: (localFile: LocalSimFile) => void;
     resetDragOverViewer: ActionCreator<ResetDragOverViewerAction>;
     isLoading: boolean;
-    fileIsDraggedOverViewer: boolean;
+    fileIsDraggedOver: boolean;
 }
 const ViewerOverlayTarget = ({
     resetDragOverViewer,
     loadLocalFile,
     isLoading,
-    fileIsDraggedOverViewer,
+    fileIsDraggedOver,
 }: ViewerOverlayTargetProps): JSX.Element | null => {
     const [showTarget, setVisibility] = useState(false);
-    if (fileIsDraggedOverViewer && !showTarget) {
+    if (fileIsDraggedOver && !showTarget) {
         setVisibility(true);
-    } else if (!fileIsDraggedOverViewer && showTarget) {
+    } else if (!fileIsDraggedOver && showTarget) {
         setVisibility(false);
     }
 

--- a/src/containers/ModelPanel/index.tsx
+++ b/src/containers/ModelPanel/index.tsx
@@ -11,7 +11,7 @@ import {
     getUiDisplayDataTree,
     getIsNetworkedFile,
 } from "../../state/trajectory/selectors";
-import { getViewerStatus } from "../../state/viewer/selectors";
+import { getStatus } from "../../state/viewer/selectors";
 import { State } from "../../state/types";
 import {
     getVisibleAgentsNamesAndTags,
@@ -134,7 +134,7 @@ function mapStateToProps(state: State) {
         payloadForSelectNone: convertUITreeDataToSelectNone(state),
         checkAllIsIntermediate: getCheckboxAllIsIntermediate(state),
         agentColors: getAgentColors(state),
-        viewerStatus: getViewerStatus(state),
+        viewerStatus: getStatus(state),
         isNetworkedFile: getIsNetworkedFile(state),
     };
 }

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -235,7 +235,7 @@ function mapStateToProps(state: State) {
         fileIsDraggedOverViewer: viewerStateBranch.selectors.getFileDraggedOverViewer(
             state
         ),
-        viewerStatus: viewerStateBranch.selectors.getViewerStatus(state),
+        viewerStatus: viewerStateBranch.selectors.getStatus(state),
     };
 }
 

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -249,7 +249,7 @@ const dispatchToPropsMap = {
     resetDragOverViewer: viewerStateBranch.actions.resetDragOverViewer,
     dragOverViewer: viewerStateBranch.actions.dragOverViewer,
     loadViaUrl: trajectoryStateBranch.actions.loadViaUrl,
-    setViewerStatus: viewerStateBranch.actions.setViewerStatus,
+    setViewerStatus: viewerStateBranch.actions.setStatus,
 };
 
 export default connect(

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -201,7 +201,7 @@ class App extends React.Component<AppProps, AppState> {
                             loadLocalFile={changeToLocalSimulariumFile}
                             isLoading={viewerStatus === VIEWER_LOADING}
                             resetDragOverViewer={resetDragOverViewer}
-                            fileIsDraggedOverViewer={fileIsDraggedOverViewer}
+                            fileIsDraggedOver={fileIsDraggedOverViewer}
                         />
                         <SideBar onCollapse={this.onPanelCollapse} type="left">
                             <ModelPanel />
@@ -232,7 +232,7 @@ function mapStateToProps(state: State) {
         simulariumController: simulariumStateBranch.selectors.getSimulariumController(
             state
         ),
-        fileIsDraggedOverViewer: viewerStateBranch.selectors.getFileDraggedOverViewer(
+        fileIsDraggedOverViewer: viewerStateBranch.selectors.getFileDraggedOver(
             state
         ),
         viewerStatus: viewerStateBranch.selectors.getStatus(state),

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -66,7 +66,7 @@ interface ViewerPanelProps {
     displayTimes: DisplayTimes;
     timeUnits: TimeUnits;
     isPlaying: boolean;
-    fileIsDraggedOverViewer: boolean;
+    fileIsDraggedOver: boolean;
     status: string;
     numFrames: number;
     isBuffering: boolean;
@@ -444,7 +444,7 @@ function mapStateToProps(state: State) {
         selectionStateInfoForViewer: getSelectionStateInfoForViewer(state),
         status: viewerStateBranch.selectors.getStatus(state),
         error: viewerStateBranch.selectors.getError(state),
-        fileIsDraggedOverViewer: viewerStateBranch.selectors.getFileDraggedOverViewer(
+        fileIsDraggedOver: viewerStateBranch.selectors.getFileDraggedOver(
             state
         ),
         isBuffering: viewerStateBranch.selectors.getIsBuffering(state),

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -67,7 +67,7 @@ interface ViewerPanelProps {
     timeUnits: TimeUnits;
     isPlaying: boolean;
     fileIsDraggedOverViewer: boolean;
-    viewerStatus: string;
+    status: string;
     numFrames: number;
     isBuffering: boolean;
     simulariumController: SimulariumController;
@@ -177,11 +177,11 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
     }
 
     public componentDidUpdate(prevProps: ViewerPanelProps) {
-        const { viewerStatus, viewerError } = this.props;
+        const { status, viewerError } = this.props;
         const current = this.centerContent.current;
         if (
-            viewerStatus === VIEWER_ERROR &&
-            prevProps.viewerStatus !== VIEWER_ERROR &&
+            status === VIEWER_ERROR &&
+            prevProps.status !== VIEWER_ERROR &&
             viewerError.message
         ) {
             return errorNotification({
@@ -268,7 +268,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         const {
             changeTime,
             setViewerStatus,
-            viewerStatus,
+            status,
             lastFrameTime,
             numFrames,
             timeStep,
@@ -289,7 +289,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             setBuffering(false),
         ];
 
-        if (viewerStatus !== VIEWER_SUCCESS) {
+        if (status !== VIEWER_SUCCESS) {
             actions.push(setViewerStatus({ status: VIEWER_SUCCESS }));
         }
 
@@ -366,7 +366,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             displayTimes,
             isBuffering,
             isPlaying,
-            viewerStatus,
+            status,
         } = this.props;
         return (
             <div
@@ -410,7 +410,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
                     firstFrameTime={firstFrameTime}
                     lastFrameTime={lastFrameTime}
                     loading={isBuffering}
-                    isEmpty={viewerStatus === VIEWER_EMPTY}
+                    isEmpty={status === VIEWER_EMPTY}
                 />
                 <ScaleBar label={this.state.scaleBarLabel} />
                 <CameraControls
@@ -442,7 +442,7 @@ function mapStateToProps(state: State) {
         displayTimes: getDisplayTimes(state),
         timeUnits: trajectoryStateBranch.selectors.getTimeUnits(state),
         selectionStateInfoForViewer: getSelectionStateInfoForViewer(state),
-        viewerStatus: viewerStateBranch.selectors.getViewerStatus(state),
+        status: viewerStateBranch.selectors.getViewerStatus(state),
         viewerError: viewerStateBranch.selectors.getViewerError(state),
         fileIsDraggedOverViewer: viewerStateBranch.selectors.getFileDraggedOverViewer(
             state

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -81,7 +81,7 @@ interface ViewerPanelProps {
     dragOverViewer: ActionCreator<DragOverViewerAction>;
     resetDragOverViewer: ActionCreator<ResetDragOverViewerAction>;
     setAgentsVisible: ActionCreator<SetVisibleAction>;
-    setViewerStatus: ActionCreator<SetViewerStatusAction>;
+    setStatus: ActionCreator<SetViewerStatusAction>;
     setAllAgentColors: ActionCreator<SetAllColorsAction>;
     viewerError: ViewerError;
     setBuffering: ActionCreator<ToggleAction>;
@@ -267,7 +267,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
     public receiveTimeChange(timeData: TimeData) {
         const {
             changeTime,
-            setViewerStatus,
+            setStatus,
             status,
             lastFrameTime,
             numFrames,
@@ -290,7 +290,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
         ];
 
         if (status !== VIEWER_SUCCESS) {
-            actions.push(setViewerStatus({ status: VIEWER_SUCCESS }));
+            actions.push(setStatus({ status: VIEWER_SUCCESS }));
         }
 
         const atLastFrame =
@@ -360,7 +360,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             lastFrameTime,
             simulariumController,
             selectionStateInfoForViewer,
-            setViewerStatus,
+            setStatus,
             timeStep,
             timeUnits,
             displayTimes,
@@ -387,7 +387,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
                     agentColors={AGENT_COLORS}
                     loadInitialData={false}
                     onError={(error) => {
-                        setViewerStatus({
+                        setStatus({
                             status: VIEWER_ERROR,
                             errorMessage: error,
                         });
@@ -460,7 +460,7 @@ const dispatchToPropsMap = {
     receiveAgentTypeIds: trajectoryStateBranch.actions.receiveAgentTypeIds,
     receiveAgentNamesAndStates:
         trajectoryStateBranch.actions.receiveAgentNamesAndStates,
-    setViewerStatus: viewerStateBranch.actions.setViewerStatus,
+    setStatus: viewerStateBranch.actions.setStatus,
     dragOverViewer: viewerStateBranch.actions.dragOverViewer,
     resetDragOverViewer: viewerStateBranch.actions.resetDragOverViewer,
     setBuffering: viewerStateBranch.actions.setBuffering,

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -442,7 +442,7 @@ function mapStateToProps(state: State) {
         displayTimes: getDisplayTimes(state),
         timeUnits: trajectoryStateBranch.selectors.getTimeUnits(state),
         selectionStateInfoForViewer: getSelectionStateInfoForViewer(state),
-        status: viewerStateBranch.selectors.getViewerStatus(state),
+        status: viewerStateBranch.selectors.getStatus(state),
         viewerError: viewerStateBranch.selectors.getViewerError(state),
         fileIsDraggedOverViewer: viewerStateBranch.selectors.getFileDraggedOverViewer(
             state

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -83,7 +83,7 @@ interface ViewerPanelProps {
     setAgentsVisible: ActionCreator<SetVisibleAction>;
     setStatus: ActionCreator<SetViewerStatusAction>;
     setAllAgentColors: ActionCreator<SetAllColorsAction>;
-    viewerError: ViewerError;
+    error: ViewerError;
     setBuffering: ActionCreator<ToggleAction>;
 }
 
@@ -127,7 +127,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
     }
 
     public componentDidMount() {
-        const { viewerError } = this.props;
+        const { error } = this.props;
         const browser = Bowser.getParser(window.navigator.userAgent);
         // Versions from https://caniuse.com/webgl2
         const isBrowserSupported = browser.satisfies({
@@ -167,27 +167,27 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             }, 200);
         }
 
-        if (viewerError) {
+        if (error) {
             return errorNotification({
-                message: viewerError.message,
-                htmlData: viewerError.htmlData,
-                onClose: viewerError.onClose,
+                message: error.message,
+                htmlData: error.htmlData,
+                onClose: error.onClose,
             });
         }
     }
 
     public componentDidUpdate(prevProps: ViewerPanelProps) {
-        const { status, viewerError } = this.props;
+        const { status, error } = this.props;
         const current = this.centerContent.current;
         if (
             status === VIEWER_ERROR &&
             prevProps.status !== VIEWER_ERROR &&
-            viewerError.message
+            error.message
         ) {
             return errorNotification({
-                message: viewerError.message,
-                htmlData: viewerError.htmlData,
-                onClose: viewerError.onClose,
+                message: error.message,
+                htmlData: error.htmlData,
+                onClose: error.onClose,
             });
         }
         if (
@@ -443,7 +443,7 @@ function mapStateToProps(state: State) {
         timeUnits: trajectoryStateBranch.selectors.getTimeUnits(state),
         selectionStateInfoForViewer: getSelectionStateInfoForViewer(state),
         status: viewerStateBranch.selectors.getStatus(state),
-        viewerError: viewerStateBranch.selectors.getViewerError(state),
+        error: viewerStateBranch.selectors.getError(state),
         fileIsDraggedOverViewer: viewerStateBranch.selectors.getFileDraggedOverViewer(
             state
         ),

--- a/src/state/README.md
+++ b/src/state/README.md
@@ -58,7 +58,7 @@ The Redux state tree in simularium-website is currently divided into 4 branches:
 * selection - selections made by the user through the UI, such as `time` and `numberPanelsCollapsed`
 * simularium - the Simularium controller
 * trajectory - current trajectory data, such as `timeStep` and `simulariumFile`
-* viewer - viewer status, such as `isBuffering` or `viewerError`
+* viewer - viewer status, such as `isBuffering` or `error`
 
 ### Glossary
 

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -19,7 +19,7 @@ import {
 import { setSimulariumController } from "../simularium/actions";
 import { getSimulariumController } from "../simularium/selectors";
 import { initialState as initialSelectionState } from "../selection/reducer";
-import { setViewerStatus, setIsPlaying } from "../viewer/actions";
+import { setStatus, setIsPlaying } from "../viewer/actions";
 import { ReduxLogicDeps } from "../types";
 import { batchActions } from "../util";
 
@@ -69,13 +69,13 @@ const resetSimulariumFileState = createLogic({
                 timeStep: initialState.timeStep,
                 agentUiNames: initialState.agentUiNames,
             });
-            const setViewerStatusAction = setViewerStatus({
+            const setViewerStatusAction = setStatus({
                 status: VIEWER_EMPTY,
             });
             actions.push(setViewerStatusAction);
         } else {
             dispatch(
-                setViewerStatus({
+                setStatus({
                     status: VIEWER_LOADING,
                 })
             );
@@ -119,7 +119,7 @@ const loadNetworkedFile = createLogic({
 
         const simulariumFile = action.payload;
         dispatch(
-            setViewerStatus({
+            setStatus({
                 status: VIEWER_LOADING,
             })
         );
@@ -161,7 +161,7 @@ const loadNetworkedFile = createLogic({
             .then(done)
             .catch((error: Error) => {
                 dispatch(
-                    setViewerStatus({
+                    setStatus({
                         status: VIEWER_ERROR,
                         errorMessage: error.message,
                     })
@@ -224,7 +224,7 @@ const loadLocalFile = createLogic({
             .then(done)
             .catch((error: FrontEndError) => {
                 dispatch(
-                    setViewerStatus({
+                    setStatus({
                         status: VIEWER_ERROR,
                         errorMessage: error.message,
                         htmlData: error.htmlData || "",
@@ -242,7 +242,7 @@ const loadFileViaUrl = createLogic({
 
         const currentState = getState();
         dispatch(
-            setViewerStatus({
+            setStatus({
                 status: VIEWER_LOADING,
             })
         );
@@ -287,7 +287,7 @@ const loadFileViaUrl = createLogic({
                         "<br/><br/>Try uploading your trajectory file from a Dropbox, Google Drive, or Amazon S3 link instead.";
                 }
                 dispatch(
-                    setViewerStatus({
+                    setStatus({
                         status: VIEWER_ERROR,
                         errorMessage: error.message,
                         htmlData: errorDetails,

--- a/src/state/viewer/actions.ts
+++ b/src/state/viewer/actions.ts
@@ -1,7 +1,7 @@
 import {
     SET_STATUS,
-    DRAG_OVER_VIEWER,
-    RESET_DRAG_OVER_VIEWER,
+    DRAG_FILE_OVER,
+    RESET_DRAG_FILE_OVER,
     SET_BUFFERING,
     SET_IS_PLAYING,
 } from "./constants";
@@ -22,13 +22,13 @@ export function setStatus(payload: ViewerStatusInfo): SetViewerStatusAction {
 
 export function dragOverViewer(): DragOverViewerAction {
     return {
-        type: DRAG_OVER_VIEWER,
+        type: DRAG_FILE_OVER,
     };
 }
 
 export function resetDragOverViewer(): ResetDragOverViewerAction {
     return {
-        type: RESET_DRAG_OVER_VIEWER,
+        type: RESET_DRAG_FILE_OVER,
     };
 }
 

--- a/src/state/viewer/actions.ts
+++ b/src/state/viewer/actions.ts
@@ -1,5 +1,5 @@
 import {
-    SET_VIEWER_STATUS,
+    SET_STATUS,
     DRAG_OVER_VIEWER,
     RESET_DRAG_OVER_VIEWER,
     SET_BUFFERING,
@@ -16,7 +16,7 @@ import {
 export function setStatus(payload: ViewerStatusInfo): SetViewerStatusAction {
     return {
         payload,
-        type: SET_VIEWER_STATUS,
+        type: SET_STATUS,
     };
 }
 

--- a/src/state/viewer/actions.ts
+++ b/src/state/viewer/actions.ts
@@ -13,9 +13,7 @@ import {
     ToggleAction,
 } from "./types";
 
-export function setViewerStatus(
-    payload: ViewerStatusInfo
-): SetViewerStatusAction {
+export function setStatus(payload: ViewerStatusInfo): SetViewerStatusAction {
     return {
         payload,
         type: SET_VIEWER_STATUS,

--- a/src/state/viewer/constants.ts
+++ b/src/state/viewer/constants.ts
@@ -4,8 +4,8 @@ const makeViewerConstant = (constant: string) =>
     makeConstant(BRANCH_NAME, constant);
 
 export const SET_STATUS = makeViewerConstant("set-status");
-export const DRAG_OVER_VIEWER = makeViewerConstant("drag-over-viewer");
-export const RESET_DRAG_OVER_VIEWER = makeViewerConstant("drag-off-viewer");
+export const DRAG_FILE_OVER = makeViewerConstant("drag-file-over");
+export const RESET_DRAG_FILE_OVER = makeViewerConstant("reset-drag-file-over");
 export const SET_BUFFERING = makeViewerConstant("set-buffering");
 export const SET_IS_PLAYING = makeViewerConstant("set-is-playing");
 

--- a/src/state/viewer/constants.ts
+++ b/src/state/viewer/constants.ts
@@ -3,7 +3,7 @@ const BRANCH_NAME = "viewer";
 const makeViewerConstant = (constant: string) =>
     makeConstant(BRANCH_NAME, constant);
 
-export const SET_VIEWER_STATUS = makeViewerConstant("set-viewer-status");
+export const SET_STATUS = makeViewerConstant("set-status");
 export const DRAG_OVER_VIEWER = makeViewerConstant("drag-over-viewer");
 export const RESET_DRAG_OVER_VIEWER = makeViewerConstant("drag-off-viewer");
 export const SET_BUFFERING = makeViewerConstant("set-buffering");

--- a/src/state/viewer/reducer.ts
+++ b/src/state/viewer/reducer.ts
@@ -22,7 +22,7 @@ import {
 
 export const initialState = {
     status: VIEWER_EMPTY,
-    viewerError: null,
+    error: null,
     draggedOverViewer: false,
     isBuffering: false,
     isPlaying: false,
@@ -35,7 +35,7 @@ const actionToConfigMap: TypeToDescriptionMap = {
         perform: (state: ViewerStateBranch, action: SetViewerStatusAction) => ({
             ...state,
             status: action.payload.status,
-            viewerError:
+            error:
                 action.payload.status === VIEWER_ERROR
                     ? {
                           message: action.payload.errorMessage,

--- a/src/state/viewer/reducer.ts
+++ b/src/state/viewer/reducer.ts
@@ -4,7 +4,7 @@ import { TypeToDescriptionMap } from "../types";
 import { makeReducer } from "../util";
 
 import {
-    SET_VIEWER_STATUS,
+    SET_STATUS,
     VIEWER_ERROR,
     VIEWER_EMPTY,
     DRAG_OVER_VIEWER,
@@ -29,9 +29,9 @@ export const initialState = {
 };
 
 const actionToConfigMap: TypeToDescriptionMap = {
-    [SET_VIEWER_STATUS]: {
+    [SET_STATUS]: {
         accepts: (action: AnyAction): action is SetViewerStatusAction =>
-            action.type === SET_VIEWER_STATUS,
+            action.type === SET_STATUS,
         perform: (state: ViewerStateBranch, action: SetViewerStatusAction) => ({
             ...state,
             status: action.payload.status,

--- a/src/state/viewer/reducer.ts
+++ b/src/state/viewer/reducer.ts
@@ -23,7 +23,7 @@ import {
 export const initialState = {
     status: VIEWER_EMPTY,
     error: null,
-    draggedOverViewer: false,
+    fileDraggedOver: false,
     isBuffering: false,
     isPlaying: false,
 };
@@ -50,7 +50,7 @@ const actionToConfigMap: TypeToDescriptionMap = {
             action.type === DRAG_OVER_VIEWER,
         perform: (state: ViewerStateBranch) => ({
             ...state,
-            draggedOverViewer: true,
+            fileDraggedOver: true,
         }),
     },
     [RESET_DRAG_OVER_VIEWER]: {
@@ -58,7 +58,7 @@ const actionToConfigMap: TypeToDescriptionMap = {
             action.type === RESET_DRAG_OVER_VIEWER,
         perform: (state: ViewerStateBranch) => ({
             ...state,
-            draggedOverViewer: false,
+            fileDraggedOver: false,
         }),
     },
     [SET_BUFFERING]: {

--- a/src/state/viewer/reducer.ts
+++ b/src/state/viewer/reducer.ts
@@ -7,8 +7,8 @@ import {
     SET_STATUS,
     VIEWER_ERROR,
     VIEWER_EMPTY,
-    DRAG_OVER_VIEWER,
-    RESET_DRAG_OVER_VIEWER,
+    DRAG_FILE_OVER,
+    RESET_DRAG_FILE_OVER,
     SET_BUFFERING,
     SET_IS_PLAYING,
 } from "./constants";
@@ -45,17 +45,17 @@ const actionToConfigMap: TypeToDescriptionMap = {
                     : "",
         }),
     },
-    [DRAG_OVER_VIEWER]: {
+    [DRAG_FILE_OVER]: {
         accepts: (action: AnyAction): action is DragOverViewerAction =>
-            action.type === DRAG_OVER_VIEWER,
+            action.type === DRAG_FILE_OVER,
         perform: (state: ViewerStateBranch) => ({
             ...state,
             fileDraggedOver: true,
         }),
     },
-    [RESET_DRAG_OVER_VIEWER]: {
+    [RESET_DRAG_FILE_OVER]: {
         accepts: (action: AnyAction): action is ResetDragOverViewerAction =>
-            action.type === RESET_DRAG_OVER_VIEWER,
+            action.type === RESET_DRAG_FILE_OVER,
         perform: (state: ViewerStateBranch) => ({
             ...state,
             fileDraggedOver: false,

--- a/src/state/viewer/reducer.ts
+++ b/src/state/viewer/reducer.ts
@@ -21,7 +21,7 @@ import {
 } from "./types";
 
 export const initialState = {
-    viewerStatus: VIEWER_EMPTY,
+    status: VIEWER_EMPTY,
     viewerError: null,
     draggedOverViewer: false,
     isBuffering: false,
@@ -34,7 +34,7 @@ const actionToConfigMap: TypeToDescriptionMap = {
             action.type === SET_VIEWER_STATUS,
         perform: (state: ViewerStateBranch, action: SetViewerStatusAction) => ({
             ...state,
-            viewerStatus: action.payload.status,
+            status: action.payload.status,
             viewerError:
                 action.payload.status === VIEWER_ERROR
                     ? {

--- a/src/state/viewer/selectors.ts
+++ b/src/state/viewer/selectors.ts
@@ -1,7 +1,7 @@
 import { State } from "../types";
 
 // BASIC SELECTORS
-export const getViewerStatus = (state: State) => state.viewer.viewerStatus;
+export const getViewerStatus = (state: State) => state.viewer.status;
 export const getViewerError = (state: State) => state.viewer.viewerError;
 export const getFileDraggedOverViewer = (state: State) =>
     state.viewer.draggedOverViewer;

--- a/src/state/viewer/selectors.ts
+++ b/src/state/viewer/selectors.ts
@@ -1,7 +1,7 @@
 import { State } from "../types";
 
 // BASIC SELECTORS
-export const getViewerStatus = (state: State) => state.viewer.status;
+export const getStatus = (state: State) => state.viewer.status;
 export const getViewerError = (state: State) => state.viewer.viewerError;
 export const getFileDraggedOverViewer = (state: State) =>
     state.viewer.draggedOverViewer;

--- a/src/state/viewer/selectors.ts
+++ b/src/state/viewer/selectors.ts
@@ -2,7 +2,7 @@ import { State } from "../types";
 
 // BASIC SELECTORS
 export const getStatus = (state: State) => state.viewer.status;
-export const getViewerError = (state: State) => state.viewer.viewerError;
+export const getError = (state: State) => state.viewer.error;
 export const getFileDraggedOverViewer = (state: State) =>
     state.viewer.draggedOverViewer;
 export const getIsBuffering = (state: State) => state.viewer.isBuffering;

--- a/src/state/viewer/selectors.ts
+++ b/src/state/viewer/selectors.ts
@@ -3,8 +3,8 @@ import { State } from "../types";
 // BASIC SELECTORS
 export const getStatus = (state: State) => state.viewer.status;
 export const getError = (state: State) => state.viewer.error;
-export const getFileDraggedOverViewer = (state: State) =>
-    state.viewer.draggedOverViewer;
+export const getFileDraggedOver = (state: State) =>
+    state.viewer.fileDraggedOver;
 export const getIsBuffering = (state: State) => state.viewer.isBuffering;
 export const getIsPlaying = (state: State) => state.viewer.isPlaying;
 


### PR DESCRIPTION
Problem
=======
We have a new state branch called `viewer` but now it contains properties with redundant names like `viewerStatus` and `viewerError` instead of `status` and `error`.

Another step towards #166 

Solution
========
See my [unusually clean] commit messages for what I renamed. This PR just contains variable renaming.

## Type of change
Please delete options that are not relevant.

* Maintenance
* This change requires a documentation update

Steps to Verify:
----------------
1. `npm start`, `npm run typeCheck` and `npm run test` and make sure nothing is broken
