### PR TITLE
Fix/ make clearTrajectory just reset to initialState

### DIFF
--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -62,13 +62,7 @@ const resetSimulariumFileState = createLogic({
             if (controller) {
                 controller.clearFile();
             }
-            clearTrajectory = receiveTrajectory({
-                plotData: initialState.plotData,
-                firstFrameTime: initialState.firstFrameTime,
-                lastFrameTime: initialState.lastFrameTime,
-                timeStep: initialState.timeStep,
-                agentUiNames: initialState.agentUiNames,
-            });
+            clearTrajectory = receiveTrajectory(initialState);
             const setViewerStatusAction = setStatus({
                 status: VIEWER_EMPTY,
             });

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -62,7 +62,7 @@ const resetSimulariumFileState = createLogic({
             if (controller) {
                 controller.clearFile();
             }
-            clearTrajectory = receiveTrajectory(initialState);
+            clearTrajectory = receiveTrajectory({...initialState});
             const setViewerStatusAction = setStatus({
                 status: VIEWER_EMPTY,
             });


### PR DESCRIPTION
Problem
=======
Closes #166 (This fix takes advantage of the Redux reorg that was recently completed)

Previously, because our Redux state tree was not organized properly, when we wanted to clear the trajectory info in our state (when loading a new trajectory) we had to specify which info (e.g. `firstFrameTime`, `timeStep`, etc.) to reset to initial state. And it seems this list of things to reset got forgotten/outdated. I'm not sure anyone ever came across a bug that arose from that, but it seems good to fix anyway.

Solution
========
Since the new `trajectory` state branch contains only the info that needs to be reset on a trajectory change, when we want to clear the trajectory info we can now just reset the entire branch to its `initialState` and not worry about forgetting a piece when we change what's in `initialState`.

You can see everything we now reset (i.e. what `initialState` looks like) here: https://github.com/allen-cell-animated/simularium-website/blob/main/src/state/trajectory/reducer.ts#L19

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. `npm start` and try switching trajectories by different loading methods. Shouldn't run into any problems.