### PR TITLE
Fix/time input box is too narrow sometimes

### DIFF
--- a/src/containers/ViewerPanel/selectors.test.ts
+++ b/src/containers/ViewerPanel/selectors.test.ts
@@ -106,6 +106,20 @@ describe("ViewerPanel selectors", () => {
             expect(maxNumChars).toBe("44.1".length);
         });
 
+        it("returns length of firstFrameTime + timeStep when time step is a lengthy float and firstFrameTime is 0", () => {
+            const firstFrameTime = 0;
+            const lastFrameTime = 5;
+            const timeStep = 0.005;
+
+            const maxNumChars = getMaxNumChars(
+                firstFrameTime,
+                lastFrameTime,
+                timeStep
+            );
+
+            expect(maxNumChars).toBe("0.005".length);
+        });
+
         it("returns length of firstFrameTime when it is longer than lastFrameTime + timeStep", () => {
             const firstFrameTime = 0.00001;
             const lastFrameTime = 44.1;

--- a/src/containers/ViewerPanel/selectors.ts
+++ b/src/containers/ViewerPanel/selectors.ts
@@ -60,16 +60,18 @@ export const getMaxNumChars = (
     lastFrameTime: number,
     timeStep: number
 ) => {
-    // If lastFrameTime is 15 and step size is 0.2 then 15.2 is probably going to have
-    // the max number of characters for this trajectory
-    const refTimeValue = lastFrameTime + timeStep;
-    const roundedRefTime = roundTimeForDisplay(refTimeValue).toString();
+    // These two time values are likely to have the most digits
+    const refTime1Value = firstFrameTime + timeStep;
+    const refTime2Value = lastFrameTime + timeStep;
+    const roundedRefTime1 = roundTimeForDisplay(refTime1Value).toString();
+    const roundedRefTime2 = roundTimeForDisplay(refTime2Value).toString();
 
     // Edge case: If firstFrameTime is a very small but long number like 0.000008,
     // we need to accommodate that.
     const maxNumChars = Math.max(
         firstFrameTime.toString().length,
-        roundedRefTime.length
+        roundedRefTime1.length,
+        roundedRefTime2.length
     );
 
     return maxNumChars;


### PR DESCRIPTION
Problem
=======
Closes #226 

Solution
========
I wrote an additional test and modified the `getMaxNumChars` function so that it passes.

In a nutshell, `getMaxNumChars` was only considering the lengths of `round(lastFrameTime + timeStep)` and `firstFrameTime` as contenders for the longest value, but when `firstFrameTime` is 0 and `timeStep` is small enough, `round(lastFrameTime + timeStep)` just becomes `lastFrameTime`. So I added `round(firstFrameTime + timeStep)` into consideration.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* This change requires updated or new tests

Steps to Verify:
----------------
1. Try to reproduce the bug outlined in the issue. You shouldn't be able to.
2. All other tests for `getMaxNumChars` still pass.

Screenshots (optional):
-----------------------
### Before:
![image](https://user-images.githubusercontent.com/12690133/129289132-b0ff5bbe-b0e0-49e3-96e9-8f6200cdc390.png)


### After:
![image](https://user-images.githubusercontent.com/12690133/129289042-e4269fef-c7f8-4b85-8865-8d1a32ba29d4.png)

