### PR TITLE
Feature/allow v3 trajectories to load (update viewer to v3.0.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,22 +15,20 @@
             }
         },
         "@aics/simularium-viewer": {
-            "version": "2.9.7",
-            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-2.9.7.tgz",
-            "integrity": "sha512-WwgMllmYF2CHPTKPibQAwZ/qsozMtciOHcs2pI2qpU0fgwbJbzSv0ZyBUbPKB2GlSSr2tMLks5ySeKtzPzsfQw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aics/simularium-viewer/-/simularium-viewer-3.0.0.tgz",
+            "integrity": "sha512-88R/j0T0IaH9aGiJa7jirfEyHtqM3cDKoF9TkHXYOCdy0yvrbDrD48EAOWX/o3jW/QmYOkTjNaQcLGNlbFKQ+Q==",
             "requires": {
                 "@fortawesome/fontawesome-free": "^5.15.2",
                 "@fortawesome/fontawesome-svg-core": "^1.2.34",
                 "@fortawesome/free-solid-svg-icons": "^5.15.2",
                 "@fortawesome/react-fontawesome": "^0.1.14",
-                "comlink": "^4.3.0",
+                "comlink": "^4.3.1",
                 "dat.gui": "^0.7.6",
                 "js-logger": "^1.6.1",
                 "parse-pdb": "^1.0.0",
-                "react": "~16.9.0",
-                "react-dom": "^16.9.0",
                 "si-prefix": "^0.2.0",
-                "three": "^0.125.2"
+                "three": "^0.131.3"
             }
         },
         "@ant-design/colors": {
@@ -1167,35 +1165,35 @@
             "dev": true
         },
         "@fortawesome/fontawesome-common-types": {
-            "version": "0.2.35",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
-            "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+            "version": "0.2.36",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+            "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
         },
         "@fortawesome/fontawesome-free": {
-            "version": "5.15.3",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.3.tgz",
-            "integrity": "sha512-rFnSUN/QOtnOAgqFRooTA3H57JLDm0QEG/jPdk+tLQNL/eWd+Aok8g3qCI+Q1xuDPWpGW/i9JySpJVsq8Q0s9w=="
+            "version": "5.15.4",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz",
+            "integrity": "sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg=="
         },
         "@fortawesome/fontawesome-svg-core": {
-            "version": "1.2.35",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
-            "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+            "version": "1.2.36",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+            "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
             "requires": {
-                "@fortawesome/fontawesome-common-types": "^0.2.35"
+                "@fortawesome/fontawesome-common-types": "^0.2.36"
             }
         },
         "@fortawesome/free-solid-svg-icons": {
-            "version": "5.15.3",
-            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
-            "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+            "version": "5.15.4",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
+            "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
             "requires": {
-                "@fortawesome/fontawesome-common-types": "^0.2.35"
+                "@fortawesome/fontawesome-common-types": "^0.2.36"
             }
         },
         "@fortawesome/react-fontawesome": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz",
-            "integrity": "sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==",
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.15.tgz",
+            "integrity": "sha512-/HFHdcoLESxxMkqZAcZ6RXDJ69pVApwdwRos/B2kiMWxDSAX2dFK8Er2/+rG+RsrzWB/dsAyjefLmemgmfE18g==",
             "requires": {
                 "prop-types": "^15.7.2"
             }
@@ -18502,9 +18500,9 @@
             "dev": true
         },
         "three": {
-            "version": "0.125.2",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
-            "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
+            "version": "0.131.3",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.131.3.tgz",
+            "integrity": "sha512-VkZAv8ZTJqiE/fyEmoWLxcNHImpVcjqW7RO0GzMu3tRpwO0KUvK9pjTmJzJcAbc51BOeB2G38zh80yjHTbP8gQ=="
         },
         "throat": {
             "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "webpack-dev-server": "^3.11.0"
     },
     "dependencies": {
-        "@aics/simularium-viewer": "^2.9.7",
+        "@aics/simularium-viewer": "^3.0.0",
         "@ant-design/css-animation": "^1.7.3",
         "@ant-design/icons": "^4.0.6",
         "antd": "^4.0.0-rc.6",


### PR DESCRIPTION
Problem
=======
Currently, if you load a v3 trajectory file to staging.simularium.allencell.org/viewer, the trajectory does not load and an error is displayed: "Invalid version number in trajectoryFileInfo:3".

Closes #246 

Solution
========
Update simularium-viewer to v3.0.0

NOTE: This PR doesn't enable all the new v3 features in simularium-website (such as locally loaded geometry files and model metadata). It just allows v3 files to load without an error and basically treats it as a v2 file. Further work is needed to enable the new v3 features.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Pull this branch, `npm i` then `npm start`
2. Load a v3 trajectory by going to http://localhost:9001/viewer?trajUrl=https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/json_v3/actin012_3_metadata.simularium
3. The trajectory should load and be playable with no errors
4. Try to play any v2 trajectory (like the ones on the landing page), they should also still work.
