### PR TITLE
Feature/auto-expand agent groups with no parent color

### DIFF
--- a/src/components/CheckBoxTree/index.tsx
+++ b/src/components/CheckBoxTree/index.tsx
@@ -240,6 +240,7 @@ class CheckBoxTree extends React.Component<CheckBoxTreeProps> {
                                     </label>
                                 </>
                             }
+                            expandByDefault={!nodeData.color}
                             key={nodeData.key}
                         >
                             {nodeData.children.length > 0 && (

--- a/src/components/TreeNode/index.tsx
+++ b/src/components/TreeNode/index.tsx
@@ -10,6 +10,7 @@ import collapseAnimation from "./collapseMotion";
 interface TreeNodeProps extends React.PropsWithChildren<any> {
     actions?: ReactNode[];
     headerContent: ReactNode;
+    expandByDefault?: boolean;
 }
 const styles = require("./style.css");
 
@@ -17,8 +18,9 @@ const TreeNode = ({
     children,
     actions = [],
     headerContent,
+    expandByDefault,
 }: TreeNodeProps): JSX.Element => {
-    const [isExpanded, setExpanded] = useState<boolean>(false);
+    const [isExpanded, setExpanded] = useState<boolean>(!!expandByDefault);
     const ref = React.createRef<HTMLDivElement>();
     const onToggle = () => {
         const isOpening = !isExpanded;


### PR DESCRIPTION
Problem
=======
Closes #270 

Solution
========
If the color passed into a `TreeNode` component is `""` (parent label has no color), have that node expanded on render.

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. `npm i` and `npm start`
2. Go here: http://localhost:9001/viewer?trajUrl=https://drive.google.com/file/d/1yxdCwU0WNMih0ApGJDqQVjCwc53NPmDo/view?usp=sharing
3. Check that the first agent (actin) is expanded by default when the trajectory loads:

    ![image](https://user-images.githubusercontent.com/12690133/139493331-3a5eb2d4-b8b9-433d-b368-efec140625cc.png)
