### PR TITLE
Fix/agent list sometimes not loading for drag-and-drop

### DIFF
--- a/src/containers/ModelPanel/index.tsx
+++ b/src/containers/ModelPanel/index.tsx
@@ -100,7 +100,7 @@ class ModelPanel extends React.Component<ModelPanelProps, {}> {
             [VIEWER_ERROR]: isNetworkedFile ? (
                 <NetworkFileFailedText />
             ) : (
-                <NoTypeMappingText />
+                checkboxTree
             ),
         };
 

--- a/src/containers/ModelPanel/index.tsx
+++ b/src/containers/ModelPanel/index.tsx
@@ -40,7 +40,6 @@ import {
     VIEWER_SUCCESS,
 } from "../../state/viewer/constants";
 import NoTrajectoriesText from "../../components/NoTrajectoriesText";
-import NoTypeMappingText from "../../components/NoTrajectoriesText/NoTypeMappingText";
 import { RequestNetworkFileAction } from "../../state/trajectory/types";
 import { ViewerStatus } from "../../state/viewer/types";
 import NetworkFileFailedText from "../../components/NoTrajectoriesText/NetworkFileFailedText";


### PR DESCRIPTION
Problem
=======
Closes #274 

Solution
========
Instead of automatically rendering a `NoTypeMappingText` component ("Unabled to load UI controls") every time an error message is received from the viewer (e.g., when a geometry file can't be found), only render it if a list of agents (type mappings) doesn't exist in the data.

The `CheckBoxTree` component does its own check to see if the array for populating the agent list is empty and displays the `NoTypeMappingText` component if empty. 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
0. `npm start` on the main branch, throttle your browser to "Fast 3G" and try to reproduce the bug described in the issue. You should see the bug.
1. Pull this branch
2. Make sure your browser is still throttled and try to reproduce the bug. The agent list should show up now and the "Unable to load UI controls" message shouldn't ever flash in the left panel.
