### PR TITLE
Fix/old error message comes back after going to landing page

### DIFF
--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -166,10 +166,6 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
                 this.resize(current);
             }, 200);
         }
-
-        if (error) {
-            return ErrorNotification({ ...error });
-        }
     }
 
     public componentDidUpdate(prevProps: ViewerPanelProps) {

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -127,7 +127,6 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
     }
 
     public componentDidMount() {
-        const { error } = this.props;
         const browser = Bowser.getParser(window.navigator.userAgent);
         // Versions from https://caniuse.com/webgl2
         const isBrowserSupported = browser.satisfies({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import "core-js/es6/set";
 
 import React from "react";
 import { render } from "react-dom";
-import { Provider, useDispatch } from "react-redux";
+import { Provider, useDispatch, batch } from "react-redux";
 import { Layout } from "antd";
 import { BrowserRouter, Switch, Route, useLocation } from "react-router-dom";
 
@@ -20,8 +20,6 @@ const { Header } = Layout;
 import "./style.css";
 import { setIsPlaying } from "./state/viewer/actions";
 import { clearSimulariumFile } from "./state/trajectory/actions";
-import { getSimulariumFile } from "./state/trajectory/selectors";
-import { getSimulariumController } from "./state/simularium/selectors";
 
 export const store = createReduxStore();
 interface LocationWithState extends Location {
@@ -34,31 +32,12 @@ function useLocationChange() {
     const dispatch = useDispatch();
 
     React.useEffect(() => {
-        if (location.pathname === VIEWER_PATHNAME) {
-            /**
-             * Gets called every time the app navigates to the Simularium page.
-             * There are 2 possible url types and 3 different states the viewer should be in
-             * when we get there:
-             * 1. Empty viewer, by clicking "launch viewer" or "load your own data" card; url: '/viewer'
-             * 2. Loading network file; url: '/viewer?trajFileName=FILE_NAME'
-             * 3. Loading a local file through the dropdown, will be reflected in the location state; url: '/viewer'
-             */
-            const state = store.getState();
-            const controller = getSimulariumController(state);
-            const simFile = getSimulariumFile(state);
-            // got here from the "load local file button" so the app is going to
-            // `/viewer`, but the loadFile action will take care of resetting state
-            // if the user clicks "Open"
-            if (location.state && location.state.localFile) {
-                return;
-            }
-            if (!location.search && controller && simFile.name) {
-                // going to /viewer, clear out any existing files
+        if (location.pathname !== VIEWER_PATHNAME) {
+            batch(() => {
+                // if we're navigating away from the viewer, stop playing and reset state
+                dispatch(setIsPlaying(false));
                 dispatch(clearSimulariumFile({ newFile: false }));
-            }
-        } else {
-            // if we're navigating away from the viewer, stop playing
-            dispatch(setIsPlaying(false));
+            });
         }
     }, [location]);
 }


### PR DESCRIPTION
Problem
=======
Closes #282 

Solution
========
Don't render an error notification at `ViewerPanel` component mount -- it is rendered at component update, and that is enough.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
Try to reproduce the error described in the issue -- you shouldn't be able to.