### PR TITLE
Fix/previous trajectory persists when new trajectory fails to load

### DIFF
--- a/src/components/LocalFileUpload/custom-request-upload.ts
+++ b/src/components/LocalFileUpload/custom-request-upload.ts
@@ -6,7 +6,6 @@ import {
 } from "rc-upload/lib/interface";
 
 import { LocalSimFile } from "../../state/trajectory/types";
-import { VIEWER_ERROR } from "../../state/viewer/constants";
 import { ViewerError, ViewerStatus } from "../../state/viewer/types";
 import { clearUrlParams } from "../../util";
 
@@ -118,7 +117,6 @@ export default (
                 message: message,
                 htmlData: "",
             });
-            setViewerStatus({ status: VIEWER_ERROR });
             clearSimulariumFile({ newFile: false });
             clearUrlParams();
             // TS thinks onError might be undefined

--- a/src/components/LocalFileUpload/custom-request-upload.ts
+++ b/src/components/LocalFileUpload/custom-request-upload.ts
@@ -8,6 +8,7 @@ import {
 import { LocalSimFile } from "../../state/trajectory/types";
 import { VIEWER_ERROR } from "../../state/viewer/constants";
 import { ViewerError, ViewerStatus } from "../../state/viewer/types";
+import { clearUrlParams } from "../../util";
 
 // Typescript's File definition is missing this function
 //  which is part of the HTML standard on all browsers
@@ -38,6 +39,11 @@ export default (
     setViewerStatus: (status: { status: ViewerStatus }) => void,
     setError: (error: ViewerError) => void
 ) => {
+    // want the loading indicator to show without any lag time
+    // as soon as user hits "Open" button or drops files,
+    // and not have to have this action called multiple places in the code.
+    clearSimulariumFile({ newFile: true });
+
     numCustomRequests++;
     if (numCustomRequests !== 1) {
         // If the user loads multiple files at once (.simularium file + geometry file(s)),
@@ -55,11 +61,6 @@ export default (
         // numCustomRequests and selectedFiles.length are both 1, so reset
         numCustomRequests = 0;
     }
-
-    // want the loading indicator to show without any lag time
-    // as soon as user hits "Open" button or drops files,
-    // and not have to have this action called multiple places in the code.
-    clearSimulariumFile({ newFile: true });
 
     const files: FileHTML[] = Array.from(selectedFiles) as FileHTML[];
 
@@ -118,6 +119,8 @@ export default (
                 htmlData: "",
             });
             setViewerStatus({ status: VIEWER_ERROR });
+            clearSimulariumFile({ newFile: false });
+            clearUrlParams();
             // TS thinks onError might be undefined
             if (onError) {
                 onError(error as UploadRequestError);

--- a/src/components/LocalFileUpload/custom-request-upload.ts
+++ b/src/components/LocalFileUpload/custom-request-upload.ts
@@ -39,11 +39,6 @@ export default (
     setViewerStatus: (status: { status: ViewerStatus }) => void,
     setError: (error: ViewerError) => void
 ) => {
-    // want the loading indicator to show without any lag time
-    // as soon as user hits "Open" button or drops files,
-    // and not have to have this action called multiple places in the code.
-    clearSimulariumFile({ newFile: true });
-
     numCustomRequests++;
     if (numCustomRequests !== 1) {
         // If the user loads multiple files at once (.simularium file + geometry file(s)),
@@ -61,6 +56,11 @@ export default (
         // numCustomRequests and selectedFiles.length are both 1, so reset
         numCustomRequests = 0;
     }
+
+    // want the loading indicator to show without any lag time
+    // as soon as user hits "Open" button or drops files,
+    // and not have to have this action called multiple places in the code.
+    clearSimulariumFile({ newFile: true });
 
     const files: FileHTML[] = Array.from(selectedFiles) as FileHTML[];
 

--- a/src/components/LocalFileUpload/custom-request-upload.ts
+++ b/src/components/LocalFileUpload/custom-request-upload.ts
@@ -6,6 +6,7 @@ import {
 } from "rc-upload/lib/interface";
 
 import { LocalSimFile } from "../../state/trajectory/types";
+import { VIEWER_ERROR } from "../../state/viewer/constants";
 import { ViewerError, ViewerStatus } from "../../state/viewer/types";
 import { clearUrlParams } from "../../util";
 
@@ -117,6 +118,7 @@ export default (
                 message: message,
                 htmlData: "",
             });
+            setViewerStatus({ status: VIEWER_ERROR });
             clearSimulariumFile({ newFile: false });
             clearUrlParams();
             // TS thinks onError might be undefined

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -141,7 +141,6 @@ class App extends React.Component<AppProps, AppState> {
                         "make sure to include 'http/https' at the beginning of the url, and check for typos",
                     onClose: clearUrlParams,
                 });
-                setViewerStatus({ status: VIEWER_ERROR });
                 setSimulariumController(controller);
             }
         };

--- a/src/containers/Simularium/index.tsx
+++ b/src/containers/Simularium/index.tsx
@@ -141,6 +141,7 @@ class App extends React.Component<AppProps, AppState> {
                         "make sure to include 'http/https' at the beginning of the url, and check for typos",
                     onClose: clearUrlParams,
                 });
+                setViewerStatus({ status: VIEWER_ERROR });
                 setSimulariumController(controller);
             }
         };

--- a/src/containers/ViewerPanel/index.tsx
+++ b/src/containers/ViewerPanel/index.tsx
@@ -70,6 +70,7 @@ interface ViewerPanelProps {
     status: string;
     numFrames: number;
     isBuffering: boolean;
+    scaleBarLabel: string;
     simulariumController: SimulariumController;
     changeTime: ActionCreator<ChangeTimeAction>;
     receiveAgentTypeIds: ActionCreator<ReceiveAction>;
@@ -92,7 +93,6 @@ interface ViewerPanelState {
     particleTypeIds: string[];
     height: number;
     width: number;
-    scaleBarLabel: string;
 }
 
 class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
@@ -116,7 +116,6 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             particleTypeIds: [],
             height: 0,
             width: 0,
-            scaleBarLabel: "",
         };
     }
 
@@ -253,10 +252,10 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             numFrames: data.totalSteps,
             timeStep: data.timeStepSize,
             timeUnits: data.timeUnits,
+            scaleBarLabel: scaleBarLabelNumber + " " + scaleBarLabelUnit,
         });
 
         this.setState({
-            scaleBarLabel: scaleBarLabelNumber + " " + scaleBarLabelUnit,
             isInitialPlay: true,
         });
     }
@@ -359,6 +358,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
             isPlaying,
             status,
             setError,
+            scaleBarLabel,
         } = this.props;
         return (
             <div
@@ -408,7 +408,7 @@ class ViewerPanel extends React.Component<ViewerPanelProps, ViewerPanelState> {
                     loading={isBuffering}
                     isEmpty={status === VIEWER_EMPTY}
                 />
-                <ScaleBar label={this.state.scaleBarLabel} />
+                <ScaleBar label={scaleBarLabel} />
                 <CameraControls
                     resetCamera={simulariumController.resetCamera}
                     zoomIn={simulariumController.zoomIn}
@@ -437,6 +437,7 @@ function mapStateToProps(state: State) {
         timeStep: trajectoryStateBranch.selectors.getTimeStep(state),
         displayTimes: getDisplayTimes(state),
         timeUnits: trajectoryStateBranch.selectors.getTimeUnits(state),
+        scaleBarLabel: trajectoryStateBranch.selectors.getScaleBarLabel(state),
         selectionStateInfoForViewer: getSelectionStateInfoForViewer(state),
         status: viewerStateBranch.selectors.getStatus(state),
         error: viewerStateBranch.selectors.getError(state),

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -296,7 +296,6 @@ const loadFileViaUrl = createLogic({
                         "<br/><br/>Try uploading your trajectory file from a Dropbox, Google Drive, or Amazon S3 link instead.";
                 }
                 batch(() => {
-                    dispatch(setStatus({ status: VIEWER_ERROR }));
                     dispatch(
                         setError({
                             level: ErrorLevel.ERROR,

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -296,6 +296,7 @@ const loadFileViaUrl = createLogic({
                         "<br/><br/>Try uploading your trajectory file from a Dropbox, Google Drive, or Amazon S3 link instead.";
                 }
                 batch(() => {
+                    dispatch(setStatus({ status: VIEWER_ERROR }));
                     dispatch(
                         setError({
                             level: ErrorLevel.ERROR,

--- a/src/state/trajectory/logics.ts
+++ b/src/state/trajectory/logics.ts
@@ -5,6 +5,7 @@ import queryString from "query-string";
 import { ErrorLevel, FrontEndError } from "@aics/simularium-viewer";
 
 import { URL_PARAM_KEY_FILE_NAME } from "../../constants";
+import { clearUrlParams } from "../../util";
 import { getUserTrajectoryUrl } from "../../util/userUrlHandling";
 import {
     VIEWER_LOADING,
@@ -28,6 +29,7 @@ import {
     receiveTrajectory,
     receiveSimulariumFile,
     requestCachedPlotData,
+    clearSimulariumFile,
 } from "./actions";
 import {
     LOAD_LOCAL_FILE_IN_VIEWER,
@@ -303,7 +305,9 @@ const loadFileViaUrl = createLogic({
                                 ),
                         })
                     );
+                    dispatch(clearSimulariumFile({ newFile: false }));
                 });
+                clearUrlParams();
                 done();
             });
     },

--- a/src/state/trajectory/reducer.ts
+++ b/src/state/trajectory/reducer.ts
@@ -21,6 +21,7 @@ export const initialState = {
     lastFrameTime: 0,
     timeStep: 0,
     timeUnits: null,
+    scaleBarLabel: "",
     agentIds: [],
     agentUiNames: [],
     plotData: [],

--- a/src/state/trajectory/selectors/basic.ts
+++ b/src/state/trajectory/selectors/basic.ts
@@ -8,6 +8,8 @@ export const getLastFrameTimeOfCachedSimulation = (state: State) =>
 export const getNumFrames = (state: State) => state.trajectory.numFrames;
 export const getTimeStep = (state: State) => state.trajectory.timeStep;
 export const getTimeUnits = (state: State) => state.trajectory.timeUnits;
+export const getScaleBarLabel = (state: State) =>
+    state.trajectory.scaleBarLabel;
 export const getSimulariumFile = (state: State) =>
     state.trajectory.simulariumFile;
 export const getAgentDisplayNamesAndStates = (state: State) =>


### PR DESCRIPTION
Problem
=======
Closes #280              

Solution
========
* Call `clearSimulariumFile` (clear out the viewer and trajectory metadata) and `clearUrlParams` (clear out the URL params in the browser address bar) every time there is an error loading a file
* Move `scaleBarLabel` from `ViewerPanel` local state to redux state so that it will get cleared along with the rest of trajectory metadata when `clearSimulariumFile` is called

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Try to reproduce the error with the steps in #280 
2. Instead of the previous trajectory sticking around, the viewer should clear and everything should return to an initial (empty viewer) state, but with a helpful error message about why the file load failed displayed on the top right corner. 

Screenshots (optional):
-----------------------
#### Before (loaded endocytosis successfully, then tried to drag-and-drop an .obj file by itself):
![image](https://user-images.githubusercontent.com/12690133/144156064-5a6cb8fc-3851-4ab7-b36a-33e535f64a4e.png)

#### After:
![image](https://user-images.githubusercontent.com/12690133/144155984-f142028a-1acb-418d-badb-f3c692d79582.png)


Keyfiles (delete if not relevant):
-----------------------
1. src/state/trajectory/logics.ts - clear sim file and URL params when there's an error loading a .simularium file via URL, from our server, or locally
2. src/components/LocalFileUpload/custom-request-upload.ts - clear sim file and URL params when there's an error while pre-processing a local upload (for example when figuring out which is the .simularium file or if a folder is loaded instead of files)
3. src/containers/ViewerPanel/index.tsx - move `scaleBarLabel` out of local state

Thanks for contributing!
